### PR TITLE
Implemented the DB path end to end.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,48 @@ Optional environment configuration:
 cp .env.example .env
 ```
 
-Result file configuration:
+Result and database configuration:
 
 ```bash
 export LAYERLEAK_FINDINGS_DIR=findings
 export LAYERLEAK_TAG_PAGE_SIZE=100
+export LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?sslmode=disable
 ```
 
 If `LAYERLEAK_FINDINGS_DIR` is not set, layerleak writes JSON findings files to `findings/` under the repo root.
 Saved findings files contain only detections, including unredacted finding values and unredacted context snippets.
 `LAYERLEAK_TAG_PAGE_SIZE` controls Docker Hub tag-list pagination for repository-wide scans.
+If `LAYERLEAK_DATABASE_URL` is set, the scanner also writes the scan to Postgres and fails the command if Postgres is unavailable or the save does not succeed.
+
+## Postgres persistence
+
+Layerleak ships versioned SQL migrations under `migrations/`.
+Migrations are manual on purpose. The scanner does not auto-create or auto-upgrade the schema.
+
+Apply the initial schema with `psql`:
+
+```bash
+psql "$LAYERLEAK_DATABASE_URL" -f migrations/0001_initial.up.sql
+```
+
+Rollback the initial schema:
+
+```bash
+psql "$LAYERLEAK_DATABASE_URL" -f migrations/0001_initial.down.sql
+```
+
+Operational defaults:
+
+- Migrations are expected to remain additive.
+- The schema keeps current deduplicated state with `first_seen_at` and `last_seen_at`; it does not keep a `scan_runs` history table yet.
+- Tag mappings are refreshed for tags touched by the current scan.
+- Findings are deduplicated canonically by `(manifest_digest, fingerprint)` and per-location provenance is stored separately.
+
+Secret-safety note:
+
+- Postgres persistence stores raw finding values and raw snippets, not only redacted previews.
+- Use a dedicated database or schema for layerleak.
+- For the safest purge path, drop the dedicated database or schema instead of trying to surgically delete individual rows.
 
 ## How to start
 
@@ -92,6 +124,7 @@ Run a scan against a public Docker Hub image:
 
 Every scan also writes a JSON findings file to the findings output directory.
 Those saved findings files contain only finding records, including the exact match value, exact source location, and unredacted snippet for each finding.
+If Postgres persistence is enabled, the same raw finding material is stored in the `findings` and `finding_occurrences` tables.
 For multi-arch images, layerleak skips attestation and provenance manifests such as `application/vnd.in-toto+json` instead of counting them as failed platform scans.
 If you pass a bare repository name such as `mongo`, layerleak enumerates all public tags in that repository, resolves each tag to a digest, groups duplicate digests, and scans the distinct targets. If you want a single image only, pass an explicit tag or digest such as `mongo:latest` or `mongo@sha256:...`.
 

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"text/tabwriter"
+	"time"
 
 	"git.tools.cloudfor.ge/andrew/layerleak/internal/config"
 	"git.tools.cloudfor.ge/andrew/layerleak/internal/detectors"
@@ -64,6 +65,19 @@ func newScanCmd() *cobra.Command {
 			}
 			defer progress.Finish()
 
+			store, err := newStore(cfg)
+			if err != nil {
+				_ = progress.Update(progressSnapshot{
+					repository: ref.Repository,
+					phase:      "Error",
+					message:    err.Error(),
+				})
+				return err
+			}
+			if closer, ok := store.(interface{ Close() error }); ok {
+				defer closer.Close()
+			}
+
 			result, err := jobs.Scan(ctx, jobs.Request{
 				Reference:    ref,
 				Platform:     platform,
@@ -83,6 +97,40 @@ func newScanCmd() *cobra.Command {
 					message:    err.Error(),
 				})
 				return err
+			}
+
+			scannedAt := time.Now().UTC()
+			if store.Name() != "noop" {
+				if err := progress.Update(progressSnapshot{
+					repository:       ref.Repository,
+					tagsCompleted:    result.TagsResolved,
+					tagsFailed:       result.TagsFailed,
+					tagsTotal:        result.TagsEnumerated,
+					targetsCompleted: result.CompletedTargetCount,
+					targetsFailed:    result.FailedTargetCount,
+					targetsTotal:     result.TargetCount,
+					findingsFound:    result.TotalFindings,
+					phase:            "Saving Results",
+					message:          "Persisting findings to Postgres",
+				}); err != nil {
+					return err
+				}
+
+				if err := store.SaveScan(ctx, buildScanRecord(ref, result, scannedAt)); err != nil {
+					_ = progress.Update(progressSnapshot{
+						repository:       ref.Repository,
+						tagsCompleted:    result.TagsResolved,
+						tagsFailed:       result.TagsFailed,
+						tagsTotal:        result.TagsEnumerated,
+						targetsCompleted: result.CompletedTargetCount,
+						targetsFailed:    result.FailedTargetCount,
+						targetsTotal:     result.TargetCount,
+						findingsFound:    result.TotalFindings,
+						phase:            "Error",
+						message:          err.Error(),
+					})
+					return err
+				}
 			}
 
 			if err := progress.Update(progressSnapshot{

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -92,6 +92,21 @@ func TestScanCommandJSONOutputAndExitCode(t *testing.T) {
 	}
 }
 
+func TestScanCommandFailsWhenDatabaseIsConfiguredButUnavailable(t *testing.T) {
+	t.Setenv("LAYERLEAK_DATABASE_URL", "postgres://postgres:postgres@127.0.0.1:1/layerleak?sslmode=disable&connect_timeout=1")
+	t.Setenv("LAYERLEAK_FINDINGS_DIR", t.TempDir())
+
+	command := newRootCmd()
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"scan", "library/app:latest", "--format", "json"})
+
+	if err := command.Execute(); err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+}
+
 type roundTripFunc func(request *http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {

--- a/cmd/scanner/storage.go
+++ b/cmd/scanner/storage.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/config"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/findings"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/jobs"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/manifest"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/storage"
+)
+
+func newStore(cfg config.Config) (storage.Store, error) {
+	if strings.TrimSpace(cfg.DatabaseURL) == "" {
+		return storage.NewNoopStore(), nil
+	}
+
+	return storage.NewPostgresStore(storage.PostgresConfig{
+		DatabaseURL: cfg.DatabaseURL,
+	})
+}
+
+func buildScanRecord(reference manifest.Reference, result jobs.Result, scannedAt time.Time) storage.ScanRecord {
+	if scannedAt.IsZero() {
+		scannedAt = time.Now().UTC()
+	} else {
+		scannedAt = scannedAt.UTC()
+	}
+
+	record := storage.ScanRecord{
+		Registry:           reference.Registry,
+		Repository:         reference.Repository,
+		RequestedReference: result.RequestedReference,
+		ResolvedReference:  result.ResolvedReference,
+		RequestedDigest:    strings.TrimSpace(result.RequestedDigest),
+		Mode:               result.Mode,
+		ScannedAt:          scannedAt,
+		DetailedFindings:   findings.DeduplicateDetailed(slices.Clone(result.DetailedFindings)),
+	}
+
+	record.Targets = make([]storage.TargetRecord, 0, len(result.Targets))
+	for _, item := range result.Targets {
+		requestedDigest := strings.TrimSpace(item.RequestedDigest)
+		if requestedDigest == "" {
+			requestedDigest = digestFromTargetReference(item.Reference)
+		}
+
+		target := storage.TargetRecord{
+			Reference:         item.Reference,
+			ResolvedReference: item.ResolvedReference,
+			RequestedDigest:   requestedDigest,
+			Tags:              slices.Clone(item.Tags),
+			Error:             strings.TrimSpace(item.Error),
+			Manifests:         make([]storage.ManifestRecord, 0, len(item.PlatformResults)),
+		}
+
+		if len(item.PlatformResults) == 0 && requestedDigest != "" {
+			status := "scanned"
+			if target.Error != "" {
+				status = "failed"
+			}
+			target.Manifests = append(target.Manifests, storage.ManifestRecord{
+				Digest:     requestedDigest,
+				RootDigest: requestedDigest,
+				Status:     status,
+				Error:      target.Error,
+			})
+		}
+
+		for _, manifestResult := range item.PlatformResults {
+			manifestDigest := strings.TrimSpace(manifestResult.ManifestDigest)
+			if manifestDigest == "" {
+				manifestDigest = requestedDigest
+			}
+
+			status := "scanned"
+			errorMessage := strings.TrimSpace(manifestResult.Error)
+			if errorMessage != "" {
+				status = "failed"
+			}
+
+			target.Manifests = append(target.Manifests, storage.ManifestRecord{
+				Digest:     manifestDigest,
+				RootDigest: firstNonEmpty(requestedDigest, manifestDigest),
+				Platform:   manifestResult.Platform,
+				Status:     status,
+				Error:      errorMessage,
+			})
+		}
+
+		record.Targets = append(record.Targets, target)
+	}
+
+	record.Tags = buildTagRecords(result.TagResults, record.Targets)
+
+	return record
+}
+
+func buildTagRecords(tagResults []jobs.TagResult, targets []storage.TargetRecord) []storage.TagRecord {
+	output := make([]storage.TagRecord, 0)
+	seen := make(map[string]struct{})
+
+	appendTag := func(item storage.TagRecord) {
+		item.Name = strings.TrimSpace(item.Name)
+		item.RootDigest = strings.TrimSpace(item.RootDigest)
+		item.ManifestDigest = strings.TrimSpace(item.ManifestDigest)
+		item.Status = strings.TrimSpace(item.Status)
+		item.Error = strings.TrimSpace(item.Error)
+		if item.Name == "" || item.Status == "" {
+			return
+		}
+		key := strings.Join([]string{
+			item.Name,
+			item.RootDigest,
+			item.ManifestDigest,
+			item.Platform.String(),
+			item.Status,
+			item.Error,
+		}, "|")
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		output = append(output, item)
+	}
+
+	for _, target := range targets {
+		rootDigest := strings.TrimSpace(target.RequestedDigest)
+		if rootDigest == "" {
+			rootDigest = digestFromTargetReference(target.Reference)
+		}
+		for _, tag := range target.Tags {
+			if len(target.Manifests) == 0 {
+				appendTag(storage.TagRecord{
+					Name:           tag,
+					RootDigest:     rootDigest,
+					ManifestDigest: rootDigest,
+					Status:         statusFromError(target.Error),
+					Error:          target.Error,
+				})
+				continue
+			}
+
+			for _, manifestRecord := range target.Manifests {
+				appendTag(storage.TagRecord{
+					Name:           tag,
+					RootDigest:     firstNonEmpty(manifestRecord.RootDigest, rootDigest, manifestRecord.Digest),
+					ManifestDigest: manifestRecord.Digest,
+					Platform:       manifestRecord.Platform,
+					Status:         manifestRecord.Status,
+					Error:          manifestRecord.Error,
+				})
+			}
+		}
+	}
+
+	for _, item := range tagResults {
+		if item.Status != "failed" {
+			continue
+		}
+		appendTag(storage.TagRecord{
+			Name:           item.Tag,
+			RootDigest:     strings.TrimSpace(item.RootDigest),
+			ManifestDigest: strings.TrimSpace(item.RootDigest),
+			Status:         "failed",
+			Error:          strings.TrimSpace(item.Error),
+		})
+	}
+
+	slices.SortFunc(output, func(left, right storage.TagRecord) int {
+		if value := strings.Compare(left.Name, right.Name); value != 0 {
+			return value
+		}
+		if value := strings.Compare(left.ManifestDigest, right.ManifestDigest); value != 0 {
+			return value
+		}
+		return strings.Compare(left.Platform.String(), right.Platform.String())
+	})
+
+	return output
+}
+
+func statusFromError(value string) string {
+	if strings.TrimSpace(value) != "" {
+		return "failed"
+	}
+	return "scanned"
+}
+
+func digestFromTargetReference(value string) string {
+	reference, err := manifest.ParseReference(value)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(reference.Digest)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/cmd/scanner/storage_test.go
+++ b/cmd/scanner/storage_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/config"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/findings"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/jobs"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/manifest"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/scanner"
+)
+
+func TestNewStoreUsesNoopWithoutDatabaseURL(t *testing.T) {
+	store, err := newStore(config.Config{})
+	if err != nil {
+		t.Fatalf("newStore() error = %v", err)
+	}
+	if store.Name() != "noop" {
+		t.Fatalf("store.Name() = %q", store.Name())
+	}
+}
+
+func TestNewStoreRejectsInvalidDatabaseURL(t *testing.T) {
+	if _, err := newStore(config.Config{
+		DatabaseURL: "mysql://root@localhost:3306/layerleak",
+	}); err == nil {
+		t.Fatal("newStore() error = nil")
+	}
+}
+
+func TestBuildScanRecordMapsMultiArchTagToPlatformManifests(t *testing.T) {
+	scannedAt := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
+	rootDigest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	amd64Digest := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	arm64Digest := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+	record := buildScanRecord(manifest.Reference{
+		Registry:    "docker.io",
+		Repository:  "library/app",
+		Original:    "library/app:latest",
+		Tag:         "latest",
+		TagExplicit: true,
+	}, jobs.Result{
+		RequestedReference: "library/app:latest",
+		Repository:         "library/app",
+		Mode:               "reference",
+		ResolvedReference:  "docker.io/library/app@" + rootDigest,
+		RequestedDigest:    rootDigest,
+		TagResults: []jobs.TagResult{
+			{Tag: "latest", RootDigest: rootDigest, Status: "scanned"},
+		},
+		Targets: []jobs.TargetResult{
+			{
+				Reference:         "docker.io/library/app@" + rootDigest,
+				ResolvedReference: "docker.io/library/app@" + rootDigest,
+				RequestedDigest:   rootDigest,
+				Tags:              []string{"latest"},
+				PlatformResults: []scanner.PlatformResult{
+					{Platform: manifest.Platform{OS: "linux", Architecture: "amd64"}, ManifestDigest: amd64Digest, FindingsCount: 1},
+					{Platform: manifest.Platform{OS: "linux", Architecture: "arm64"}, ManifestDigest: arm64Digest, FindingsCount: 1},
+				},
+			},
+		},
+		DetailedFindings: []findings.DetailedFinding{
+			testDetailedFindingForManifest(amd64Digest, manifest.Platform{OS: "linux", Architecture: "amd64"}),
+			testDetailedFindingForManifest(arm64Digest, manifest.Platform{OS: "linux", Architecture: "arm64"}),
+		},
+	}, scannedAt)
+
+	if record.ScannedAt != scannedAt {
+		t.Fatalf("record.ScannedAt = %s", record.ScannedAt)
+	}
+	if len(record.Targets) != 1 {
+		t.Fatalf("len(record.Targets) = %d", len(record.Targets))
+	}
+	if len(record.Targets[0].Manifests) != 2 {
+		t.Fatalf("len(record.Targets[0].Manifests) = %d", len(record.Targets[0].Manifests))
+	}
+	if len(record.Tags) != 2 {
+		t.Fatalf("len(record.Tags) = %d", len(record.Tags))
+	}
+	for _, item := range record.Tags {
+		if item.Name != "latest" {
+			t.Fatalf("item.Name = %q", item.Name)
+		}
+		if item.RootDigest != rootDigest {
+			t.Fatalf("item.RootDigest = %q", item.RootDigest)
+		}
+		if item.ManifestDigest != amd64Digest && item.ManifestDigest != arm64Digest {
+			t.Fatalf("item.ManifestDigest = %q", item.ManifestDigest)
+		}
+	}
+}
+
+func TestBuildScanRecordMapsRepositoryTagGroups(t *testing.T) {
+	digestOne := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	digestTwo := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	record := buildScanRecord(manifest.Reference{
+		Registry:   "docker.io",
+		Repository: "library/app",
+		Original:   "library/app",
+	}, jobs.Result{
+		RequestedReference: "library/app",
+		Repository:         "library/app",
+		Mode:               "repository",
+		TagResults: []jobs.TagResult{
+			{Tag: "latest", RootDigest: digestOne, Status: "resolved"},
+			{Tag: "2.0", RootDigest: digestOne, Status: "resolved"},
+			{Tag: "1.0", RootDigest: digestTwo, Status: "resolved"},
+		},
+		Targets: []jobs.TargetResult{
+			{
+				Reference:         "docker.io/library/app@" + digestOne,
+				ResolvedReference: "docker.io/library/app@" + digestOne,
+				RequestedDigest:   digestOne,
+				Tags:              []string{"2.0", "latest"},
+				PlatformResults: []scanner.PlatformResult{
+					{Platform: manifest.Platform{OS: "linux", Architecture: "amd64"}, ManifestDigest: digestOne, FindingsCount: 1},
+				},
+			},
+			{
+				Reference:         "docker.io/library/app@" + digestTwo,
+				ResolvedReference: "docker.io/library/app@" + digestTwo,
+				RequestedDigest:   digestTwo,
+				Tags:              []string{"1.0"},
+				PlatformResults: []scanner.PlatformResult{
+					{Platform: manifest.Platform{OS: "linux", Architecture: "amd64"}, ManifestDigest: digestTwo, FindingsCount: 1},
+				},
+			},
+		},
+	}, time.Now().UTC())
+
+	if len(record.Targets) != 2 {
+		t.Fatalf("len(record.Targets) = %d", len(record.Targets))
+	}
+	if len(record.Tags) != 3 {
+		t.Fatalf("len(record.Tags) = %d", len(record.Tags))
+	}
+	if record.Tags[0].Name != "1.0" {
+		t.Fatalf("record.Tags[0].Name = %q", record.Tags[0].Name)
+	}
+	if record.Tags[1].Name != "2.0" {
+		t.Fatalf("record.Tags[1].Name = %q", record.Tags[1].Name)
+	}
+	if record.Tags[2].Name != "latest" {
+		t.Fatalf("record.Tags[2].Name = %q", record.Tags[2].Name)
+	}
+}
+
+func TestBuildScanRecordCreatesFailedManifestForFailedTarget(t *testing.T) {
+	digest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	record := buildScanRecord(manifest.Reference{
+		Registry:   "docker.io",
+		Repository: "library/app",
+		Original:   "library/app",
+	}, jobs.Result{
+		RequestedReference: "library/app",
+		Repository:         "library/app",
+		Mode:               "repository",
+		TagResults: []jobs.TagResult{
+			{Tag: "latest", RootDigest: digest, Status: "resolved"},
+		},
+		Targets: []jobs.TargetResult{
+			{
+				Reference: "docker.io/library/app@" + digest,
+				Tags:      []string{"latest"},
+				Error:     "fetch config blob: status=404",
+			},
+		},
+	}, time.Now().UTC())
+
+	if len(record.Targets) != 1 {
+		t.Fatalf("len(record.Targets) = %d", len(record.Targets))
+	}
+	if len(record.Targets[0].Manifests) != 1 {
+		t.Fatalf("len(record.Targets[0].Manifests) = %d", len(record.Targets[0].Manifests))
+	}
+	if record.Targets[0].Manifests[0].Digest != digest {
+		t.Fatalf("record.Targets[0].Manifests[0].Digest = %q", record.Targets[0].Manifests[0].Digest)
+	}
+	if record.Targets[0].Manifests[0].Status != "failed" {
+		t.Fatalf("record.Targets[0].Manifests[0].Status = %q", record.Targets[0].Manifests[0].Status)
+	}
+	if len(record.Tags) != 1 {
+		t.Fatalf("len(record.Tags) = %d", len(record.Tags))
+	}
+	if record.Tags[0].Status != "failed" {
+		t.Fatalf("record.Tags[0].Status = %q", record.Tags[0].Status)
+	}
+}
+
+func testDetailedFindingForManifest(manifestDigest string, platform manifest.Platform) findings.DetailedFinding {
+	return findings.DetailedFinding{
+		Finding: findings.Finding{
+			DetectorName:        "github_token",
+			Confidence:          "high",
+			SourceType:          findings.SourceTypeEnv,
+			ManifestDigest:      manifestDigest,
+			Platform:            platform,
+			Key:                 "GH_TOKEN",
+			RedactedValue:       "ghp********************************56",
+			Fingerprint:         manifestDigest,
+			ContextSnippet:      "GH_TOKEN=ghp********************************56",
+			PresentInFinalImage: true,
+		},
+		Value:          "ghp_123456789012345678901234567890123456",
+		RawSnippet:     "GH_TOKEN=ghp_123456789012345678901234567890123456",
+		SourceLocation: "env:GH_TOKEN",
+		MatchStart:     9,
+		MatchEnd:       49,
+	}
+}

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1,0 +1,477 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/findings"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/manifest"
+	"github.com/lib/pq"
+)
+
+type PostgresStore struct {
+	db *sql.DB
+}
+
+func NewPostgresStore(config PostgresConfig) (*PostgresStore, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("postgres", strings.TrimSpace(config.DatabaseURL))
+	if err != nil {
+		return nil, fmt.Errorf("open postgres connection: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("ping postgres: %w", err)
+	}
+
+	return &PostgresStore{db: db}, nil
+}
+
+func (s *PostgresStore) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *PostgresStore) Name() string {
+	return "postgres"
+}
+
+func (s *PostgresStore) SaveScan(ctx context.Context, record ScanRecord) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("postgres store is not initialized")
+	}
+	if err := validateScanRecord(record); err != nil {
+		return err
+	}
+
+	scannedAt := record.ScannedAt.UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin scan transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	repositoryID, err := upsertRepository(ctx, tx, record, scannedAt)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range collectManifestRecords(record) {
+		if err := upsertManifest(ctx, tx, item, scannedAt); err != nil {
+			return err
+		}
+		if err := upsertRepositoryManifest(ctx, tx, repositoryID, item, scannedAt); err != nil {
+			return err
+		}
+	}
+
+	if err := replaceTagMappings(ctx, tx, repositoryID, normalizeTagRecords(record.Tags), scannedAt); err != nil {
+		return err
+	}
+
+	for _, item := range findings.DeduplicateDetailed(record.DetailedFindings) {
+		findingID, err := upsertFinding(ctx, tx, item, scannedAt)
+		if err != nil {
+			return err
+		}
+		if err := upsertFindingOccurrence(ctx, tx, findingID, item, scannedAt); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit scan transaction: %w", err)
+	}
+
+	return nil
+}
+
+func upsertRepository(ctx context.Context, tx *sql.Tx, record ScanRecord, scannedAt time.Time) (int64, error) {
+	var repositoryID int64
+	if err := tx.QueryRowContext(ctx, `
+		INSERT INTO repositories (registry, repository, first_seen_at, last_seen_at)
+		VALUES ($1, $2, $3, $3)
+		ON CONFLICT (registry, repository)
+		DO UPDATE SET last_seen_at = EXCLUDED.last_seen_at
+		RETURNING id
+	`, strings.TrimSpace(record.Registry), strings.TrimSpace(record.Repository), scannedAt).Scan(&repositoryID); err != nil {
+		return 0, fmt.Errorf("upsert repository: %w", err)
+	}
+
+	return repositoryID, nil
+}
+
+func upsertManifest(ctx context.Context, tx *sql.Tx, item ManifestRecord, scannedAt time.Time) error {
+	item = normalizeManifestRecord(item)
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO manifests (
+			digest,
+			platform_os,
+			platform_architecture,
+			platform_variant,
+			first_seen_at,
+			last_seen_at,
+			last_scan_status,
+			last_scan_error
+		)
+		VALUES ($1, $2, $3, $4, $5, $5, $6, $7)
+		ON CONFLICT (digest)
+		DO UPDATE SET
+			platform_os = CASE
+				WHEN EXCLUDED.platform_os <> '' THEN EXCLUDED.platform_os
+				ELSE manifests.platform_os
+			END,
+			platform_architecture = CASE
+				WHEN EXCLUDED.platform_architecture <> '' THEN EXCLUDED.platform_architecture
+				ELSE manifests.platform_architecture
+			END,
+			platform_variant = CASE
+				WHEN EXCLUDED.platform_variant <> '' THEN EXCLUDED.platform_variant
+				ELSE manifests.platform_variant
+			END,
+			last_seen_at = EXCLUDED.last_seen_at,
+			last_scan_status = EXCLUDED.last_scan_status,
+			last_scan_error = EXCLUDED.last_scan_error
+	`, item.Digest, item.Platform.OS, item.Platform.Architecture, item.Platform.Variant, scannedAt, item.Status, item.Error); err != nil {
+		return fmt.Errorf("upsert manifest %s: %w", item.Digest, err)
+	}
+
+	return nil
+}
+
+func upsertRepositoryManifest(ctx context.Context, tx *sql.Tx, repositoryID int64, item ManifestRecord, scannedAt time.Time) error {
+	item = normalizeManifestRecord(item)
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO repository_manifests (
+			repository_id,
+			manifest_digest,
+			root_digest,
+			first_seen_at,
+			last_seen_at,
+			last_scan_status,
+			last_scan_error
+		)
+		VALUES ($1, $2, $3, $4, $4, $5, $6)
+		ON CONFLICT (repository_id, manifest_digest)
+		DO UPDATE SET
+			root_digest = EXCLUDED.root_digest,
+			last_seen_at = EXCLUDED.last_seen_at,
+			last_scan_status = EXCLUDED.last_scan_status,
+			last_scan_error = EXCLUDED.last_scan_error
+	`, repositoryID, item.Digest, item.RootDigest, scannedAt, item.Status, item.Error); err != nil {
+		return fmt.Errorf("upsert repository manifest %s: %w", item.Digest, err)
+	}
+
+	return nil
+}
+
+func replaceTagMappings(ctx context.Context, tx *sql.Tx, repositoryID int64, items []TagRecord, scannedAt time.Time) error {
+	tagNames := uniqueTagNames(items)
+	if len(tagNames) > 0 {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM tags
+			WHERE repository_id = $1 AND tag = ANY($2)
+		`, repositoryID, pq.Array(tagNames)); err != nil {
+			return fmt.Errorf("delete existing tag mappings: %w", err)
+		}
+	}
+
+	for _, item := range items {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO tags (
+				repository_id,
+				tag,
+				manifest_digest,
+				root_digest,
+				platform_os,
+				platform_architecture,
+				platform_variant,
+				status,
+				error,
+				first_seen_at,
+				last_seen_at
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
+		`, repositoryID, item.Name, item.ManifestDigest, item.RootDigest, item.Platform.OS, item.Platform.Architecture, item.Platform.Variant, item.Status, item.Error, scannedAt); err != nil {
+			return fmt.Errorf("insert tag mapping %s: %w", item.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func upsertFinding(ctx context.Context, tx *sql.Tx, item findings.DetailedFinding, scannedAt time.Time) (int64, error) {
+	var findingID int64
+	if err := tx.QueryRowContext(ctx, `
+		INSERT INTO findings (
+			manifest_digest,
+			fingerprint,
+			redacted_value,
+			value,
+			first_seen_at,
+			last_seen_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $5)
+		ON CONFLICT (manifest_digest, fingerprint)
+		DO UPDATE SET
+			redacted_value = EXCLUDED.redacted_value,
+			value = EXCLUDED.value,
+			last_seen_at = EXCLUDED.last_seen_at
+		RETURNING id
+	`, strings.TrimSpace(item.ManifestDigest), strings.TrimSpace(item.Fingerprint), item.RedactedValue, item.Value, scannedAt).Scan(&findingID); err != nil {
+		return 0, fmt.Errorf("upsert finding %s/%s: %w", item.ManifestDigest, item.Fingerprint, err)
+	}
+
+	return findingID, nil
+}
+
+func upsertFindingOccurrence(ctx context.Context, tx *sql.Tx, findingID int64, item findings.DetailedFinding, scannedAt time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO finding_occurrences (
+			finding_id,
+			detector_name,
+			confidence,
+			source_type,
+			platform_os,
+			platform_architecture,
+			platform_variant,
+			file_path,
+			layer_digest,
+			source_key,
+			context_snippet,
+			raw_snippet,
+			source_location,
+			match_start,
+			match_end,
+			present_in_final_image,
+			first_seen_at,
+			last_seen_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $17)
+		ON CONFLICT (
+			finding_id,
+			detector_name,
+			confidence,
+			source_type,
+			platform_os,
+			platform_architecture,
+			platform_variant,
+			file_path,
+			layer_digest,
+			source_key,
+			context_snippet,
+			raw_snippet,
+			source_location,
+			match_start,
+			match_end,
+			present_in_final_image
+		)
+		DO UPDATE SET last_seen_at = EXCLUDED.last_seen_at
+	`, findingID, item.DetectorName, item.Confidence, string(item.SourceType), item.Platform.OS, item.Platform.Architecture, item.Platform.Variant, item.FilePath, item.LayerDigest, item.Key, item.ContextSnippet, item.RawSnippet, item.SourceLocation, item.MatchStart, item.MatchEnd, item.PresentInFinalImage, scannedAt); err != nil {
+		return fmt.Errorf("upsert finding occurrence %s/%s: %w", item.ManifestDigest, item.Fingerprint, err)
+	}
+
+	return nil
+}
+
+func collectManifestRecords(record ScanRecord) []ManifestRecord {
+	manifestsByDigest := make(map[string]ManifestRecord)
+	for _, target := range record.Targets {
+		rootDigest := strings.TrimSpace(target.RequestedDigest)
+		if rootDigest == "" {
+			rootDigest = digestFromReference(target.Reference)
+		}
+
+		for _, item := range target.Manifests {
+			item.RootDigest = firstNonEmpty(item.RootDigest, rootDigest, item.Digest)
+			upsertManifestRecord(manifestsByDigest, item)
+		}
+
+		if len(target.Manifests) == 0 && rootDigest != "" && strings.TrimSpace(target.Error) != "" {
+			upsertManifestRecord(manifestsByDigest, ManifestRecord{
+				Digest:     rootDigest,
+				RootDigest: rootDigest,
+				Status:     "failed",
+				Error:      strings.TrimSpace(target.Error),
+			})
+		}
+	}
+
+	for _, item := range record.DetailedFindings {
+		upsertManifestRecord(manifestsByDigest, ManifestRecord{
+			Digest:     strings.TrimSpace(item.ManifestDigest),
+			RootDigest: strings.TrimSpace(item.ManifestDigest),
+			Platform:   item.Platform,
+			Status:     "scanned",
+		})
+	}
+
+	items := make([]ManifestRecord, 0, len(manifestsByDigest))
+	for _, item := range manifestsByDigest {
+		items = append(items, normalizeManifestRecord(item))
+	}
+	slices.SortFunc(items, func(left, right ManifestRecord) int {
+		return strings.Compare(left.Digest, right.Digest)
+	})
+
+	return items
+}
+
+func upsertManifestRecord(items map[string]ManifestRecord, incoming ManifestRecord) {
+	incoming = normalizeManifestRecord(incoming)
+	if incoming.Digest == "" {
+		return
+	}
+
+	current, ok := items[incoming.Digest]
+	if !ok {
+		items[incoming.Digest] = incoming
+		return
+	}
+
+	current.RootDigest = firstNonEmpty(current.RootDigest, incoming.RootDigest, current.Digest)
+	current.Platform = mergePlatform(current.Platform, incoming.Platform)
+	switch {
+	case current.Status == "scanned":
+	case incoming.Status == "scanned":
+		current.Status = incoming.Status
+		current.Error = ""
+	case current.Status == "":
+		current.Status = incoming.Status
+		current.Error = incoming.Error
+	case current.Status == "failed" && incoming.Error != "":
+		current.Error = incoming.Error
+	}
+	if current.Error == "" && incoming.Error != "" && current.Status != "scanned" {
+		current.Error = incoming.Error
+	}
+
+	items[incoming.Digest] = current
+}
+
+func normalizeManifestRecord(item ManifestRecord) ManifestRecord {
+	item.Digest = strings.TrimSpace(item.Digest)
+	item.RootDigest = firstNonEmpty(strings.TrimSpace(item.RootDigest), item.Digest)
+	item.Status = strings.TrimSpace(item.Status)
+	item.Error = strings.TrimSpace(item.Error)
+	item.Platform = manifest.Platform{
+		OS:           strings.TrimSpace(item.Platform.OS),
+		Architecture: strings.TrimSpace(item.Platform.Architecture),
+		Variant:      strings.TrimSpace(item.Platform.Variant),
+	}
+	if item.Status == "" {
+		item.Status = "scanned"
+	}
+
+	return item
+}
+
+func normalizeTagRecords(items []TagRecord) []TagRecord {
+	normalized := make([]TagRecord, 0, len(items))
+	seen := make(map[string]struct{})
+	for _, item := range items {
+		item = TagRecord{
+			Name:           strings.TrimSpace(item.Name),
+			RootDigest:     strings.TrimSpace(item.RootDigest),
+			ManifestDigest: strings.TrimSpace(item.ManifestDigest),
+			Platform: manifest.Platform{
+				OS:           strings.TrimSpace(item.Platform.OS),
+				Architecture: strings.TrimSpace(item.Platform.Architecture),
+				Variant:      strings.TrimSpace(item.Platform.Variant),
+			},
+			Status: strings.TrimSpace(item.Status),
+			Error:  strings.TrimSpace(item.Error),
+		}
+		if item.Name == "" || item.Status == "" {
+			continue
+		}
+		key := strings.Join([]string{
+			item.Name,
+			item.RootDigest,
+			item.ManifestDigest,
+			item.Platform.String(),
+			item.Status,
+			item.Error,
+		}, "|")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, item)
+	}
+
+	slices.SortFunc(normalized, func(left, right TagRecord) int {
+		if value := strings.Compare(left.Name, right.Name); value != 0 {
+			return value
+		}
+		if value := strings.Compare(left.ManifestDigest, right.ManifestDigest); value != 0 {
+			return value
+		}
+		return strings.Compare(left.Platform.String(), right.Platform.String())
+	})
+
+	return normalized
+}
+
+func uniqueTagNames(items []TagRecord) []string {
+	seen := make(map[string]struct{})
+	output := make([]string, 0, len(items))
+	for _, item := range items {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		output = append(output, name)
+	}
+	slices.Sort(output)
+	return output
+}
+
+func mergePlatform(current, incoming manifest.Platform) manifest.Platform {
+	if strings.TrimSpace(current.OS) == "" {
+		current.OS = strings.TrimSpace(incoming.OS)
+	}
+	if strings.TrimSpace(current.Architecture) == "" {
+		current.Architecture = strings.TrimSpace(incoming.Architecture)
+	}
+	if strings.TrimSpace(current.Variant) == "" {
+		current.Variant = strings.TrimSpace(incoming.Variant)
+	}
+
+	return current
+}
+
+func digestFromReference(value string) string {
+	reference, err := manifest.ParseReference(value)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(reference.Digest)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -3,17 +3,51 @@ package storage
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
 	"git.tools.cloudfor.ge/andrew/layerleak/internal/findings"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/manifest"
 )
 
 type ScanRecord struct {
+	Registry           string
+	Repository         string
+	RequestedReference string
+	ResolvedReference  string
+	RequestedDigest    string
+	Mode               string
+	ScannedAt          time.Time
+	Tags               []TagRecord
+	Targets            []TargetRecord
+	DetailedFindings   []findings.DetailedFinding
+}
+
+type TagRecord struct {
+	Name           string
+	RootDigest     string
 	ManifestDigest string
-	ImageReference string
-	Findings       []findings.Finding
-	ScannedAt      time.Time
+	Platform       manifest.Platform
+	Status         string
+	Error          string
+}
+
+type TargetRecord struct {
+	Reference         string
+	ResolvedReference string
+	RequestedDigest   string
+	Tags              []string
+	Error             string
+	Manifests         []ManifestRecord
+}
+
+type ManifestRecord struct {
+	Digest     string
+	RootDigest string
+	Platform   manifest.Platform
+	Status     string
+	Error      string
 }
 
 type Store interface {
@@ -43,6 +77,67 @@ func (c PostgresConfig) Validate() error {
 	if strings.TrimSpace(c.DatabaseURL) == "" {
 		return fmt.Errorf("database url is required")
 	}
+	parsed, err := url.Parse(strings.TrimSpace(c.DatabaseURL))
+	if err != nil {
+		return fmt.Errorf("parse database url: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(parsed.Scheme)) {
+	case "postgres", "postgresql":
+	default:
+		return fmt.Errorf("database url must use postgres scheme")
+	}
 
 	return nil
+}
+
+func validateScanRecord(record ScanRecord) error {
+	if strings.TrimSpace(record.Registry) == "" {
+		return fmt.Errorf("scan record registry is required")
+	}
+	if strings.TrimSpace(record.Repository) == "" {
+		return fmt.Errorf("scan record repository is required")
+	}
+	if record.ScannedAt.IsZero() {
+		return fmt.Errorf("scan record scanned at is required")
+	}
+
+	for _, item := range record.Tags {
+		if strings.TrimSpace(item.Name) == "" {
+			return fmt.Errorf("tag name is required")
+		}
+		if !isValidScanStatus(item.Status) {
+			return fmt.Errorf("tag %s status is invalid: %s", item.Name, item.Status)
+		}
+	}
+
+	for _, item := range record.Targets {
+		for _, manifest := range item.Manifests {
+			if strings.TrimSpace(manifest.Digest) == "" {
+				return fmt.Errorf("target manifest digest is required")
+			}
+			if !isValidScanStatus(manifest.Status) {
+				return fmt.Errorf("manifest %s status is invalid: %s", manifest.Digest, manifest.Status)
+			}
+		}
+	}
+
+	for _, item := range record.DetailedFindings {
+		if strings.TrimSpace(item.ManifestDigest) == "" {
+			return fmt.Errorf("finding manifest digest is required")
+		}
+		if strings.TrimSpace(item.Fingerprint) == "" {
+			return fmt.Errorf("finding fingerprint is required")
+		}
+	}
+
+	return nil
+}
+
+func isValidScanStatus(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "scanned", "failed":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -1,0 +1,324 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/findings"
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/manifest"
+	_ "github.com/lib/pq"
+)
+
+func TestMigrationFilesApplyAndRollback(t *testing.T) {
+	db := openIntegrationDB(t)
+	defer db.Close()
+
+	if err := applyMigrationSet(t, db, "*.up.sql"); err != nil {
+		t.Fatalf("applyMigrationSet(up) error = %v", err)
+	}
+	if !tableExists(t, db, "repositories") {
+		t.Fatal("repositories table was not created")
+	}
+
+	if err := applyMigrationSet(t, db, "*.down.sql"); err != nil {
+		t.Fatalf("applyMigrationSet(down) error = %v", err)
+	}
+	if tableExists(t, db, "repositories") {
+		t.Fatal("repositories table still exists after rollback")
+	}
+}
+
+func TestPostgresStoreSaveScanUpsertsAndRetainsProvenance(t *testing.T) {
+	db := openIntegrationDB(t)
+	defer db.Close()
+	if err := applyMigrationSet(t, db, "*.up.sql"); err != nil {
+		t.Fatalf("applyMigrationSet() error = %v", err)
+	}
+
+	store, err := NewPostgresStore(PostgresConfig{DatabaseURL: integrationDatabaseURL(t)})
+	if err != nil {
+		t.Fatalf("NewPostgresStore() error = %v", err)
+	}
+	defer store.Close()
+
+	record := integrationScanRecord(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+	if err := store.SaveScan(context.Background(), record); err != nil {
+		t.Fatalf("SaveScan() error = %v", err)
+	}
+	record.ScannedAt = record.ScannedAt.Add(2 * time.Hour)
+	if err := store.SaveScan(context.Background(), record); err != nil {
+		t.Fatalf("SaveScan() second error = %v", err)
+	}
+
+	assertCount(t, db, "SELECT COUNT(*) FROM findings", 1)
+	assertCount(t, db, "SELECT COUNT(*) FROM finding_occurrences", 2)
+
+	var value string
+	if err := db.QueryRow("SELECT value FROM findings").Scan(&value); err != nil {
+		t.Fatalf("QueryRow(value) error = %v", err)
+	}
+	if value != "ghp_123456789012345678901234567890123456" {
+		t.Fatalf("value = %q", value)
+	}
+
+	var rawSnippet string
+	if err := db.QueryRow("SELECT raw_snippet FROM finding_occurrences ORDER BY source_location LIMIT 1").Scan(&rawSnippet); err != nil {
+		t.Fatalf("QueryRow(raw_snippet) error = %v", err)
+	}
+	if !strings.Contains(rawSnippet, "ghp_123456789012345678901234567890123456") {
+		t.Fatalf("rawSnippet = %q", rawSnippet)
+	}
+}
+
+func TestPostgresStoreSaveScanReplacesTouchedTagMappings(t *testing.T) {
+	db := openIntegrationDB(t)
+	defer db.Close()
+	if err := applyMigrationSet(t, db, "*.up.sql"); err != nil {
+		t.Fatalf("applyMigrationSet() error = %v", err)
+	}
+
+	store, err := NewPostgresStore(PostgresConfig{DatabaseURL: integrationDatabaseURL(t)})
+	if err != nil {
+		t.Fatalf("NewPostgresStore() error = %v", err)
+	}
+	defer store.Close()
+
+	first := integrationScanRecord(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+	second := integrationScanRecord(time.Date(2026, time.March, 15, 13, 0, 0, 0, time.UTC))
+	second.Tags = []TagRecord{
+		{
+			Name:           "latest",
+			RootDigest:     "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			ManifestDigest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			Platform:       manifest.Platform{OS: "linux", Architecture: "amd64"},
+			Status:         "scanned",
+		},
+	}
+	second.Targets = []TargetRecord{
+		{
+			Reference:       "docker.io/library/app@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			RequestedDigest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			Tags:            []string{"latest"},
+			Manifests: []ManifestRecord{
+				{
+					Digest:     "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+					RootDigest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+					Platform:   manifest.Platform{OS: "linux", Architecture: "amd64"},
+					Status:     "scanned",
+				},
+			},
+		},
+	}
+	for index := range second.DetailedFindings {
+		second.DetailedFindings[index].ManifestDigest = "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+		second.DetailedFindings[index].Platform = manifest.Platform{OS: "linux", Architecture: "amd64"}
+	}
+
+	if err := store.SaveScan(context.Background(), first); err != nil {
+		t.Fatalf("SaveScan(first) error = %v", err)
+	}
+	if err := store.SaveScan(context.Background(), second); err != nil {
+		t.Fatalf("SaveScan(second) error = %v", err)
+	}
+
+	assertCount(t, db, "SELECT COUNT(*) FROM tags", 1)
+
+	var manifestDigest string
+	if err := db.QueryRow("SELECT manifest_digest FROM tags").Scan(&manifestDigest); err != nil {
+		t.Fatalf("QueryRow(manifest_digest) error = %v", err)
+	}
+	if manifestDigest != "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" {
+		t.Fatalf("manifestDigest = %q", manifestDigest)
+	}
+}
+
+func openIntegrationDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("postgres", integrationDatabaseURL(t))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec("DROP SCHEMA IF EXISTS layerleak_test CASCADE")
+	})
+
+	if _, err := db.Exec("CREATE SCHEMA IF NOT EXISTS layerleak_test"); err != nil {
+		t.Fatalf("create schema error = %v", err)
+	}
+	if _, err := db.Exec("DROP SCHEMA layerleak_test CASCADE"); err != nil {
+		t.Fatalf("drop schema error = %v", err)
+	}
+	if _, err := db.Exec("CREATE SCHEMA layerleak_test"); err != nil {
+		t.Fatalf("recreate schema error = %v", err)
+	}
+
+	return db
+}
+
+func integrationDatabaseURL(t *testing.T) string {
+	t.Helper()
+
+	baseURL := strings.TrimSpace(os.Getenv("LAYERLEAK_TEST_DATABASE_URL"))
+	if baseURL == "" {
+		t.Skip("LAYERLEAK_TEST_DATABASE_URL is not set")
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	values := parsed.Query()
+	values.Set("search_path", "layerleak_test")
+	parsed.RawQuery = values.Encode()
+	return parsed.String()
+}
+
+func applyMigrationSet(t *testing.T, db *sql.DB, pattern string) error {
+	t.Helper()
+
+	files, err := filepath.Glob(filepath.Join(repoRoot(t), "migrations", pattern))
+	if err != nil {
+		return err
+	}
+	slices.Sort(files)
+	for _, filePath := range files {
+		body, err := os.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(string(body)) == "" {
+			continue
+		}
+		if _, err := db.Exec(string(body)); err != nil {
+			return fmt.Errorf("%s: %w", filepath.Base(filePath), err)
+		}
+	}
+	return nil
+}
+
+func tableExists(t *testing.T, db *sql.DB, table string) bool {
+	t.Helper()
+
+	var exists bool
+	if err := db.QueryRow("SELECT to_regclass($1) IS NOT NULL", table).Scan(&exists); err != nil {
+		t.Fatalf("QueryRow(to_regclass) error = %v", err)
+	}
+	return exists
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	current, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(current, "go.mod")); err == nil {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			t.Fatal("repo root not found")
+		}
+		current = parent
+	}
+}
+
+func assertCount(t *testing.T, db *sql.DB, query string, want int) {
+	t.Helper()
+
+	var got int
+	if err := db.QueryRow(query).Scan(&got); err != nil {
+		t.Fatalf("QueryRow(count) error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("%s = %d, want %d", query, got, want)
+	}
+}
+
+func integrationScanRecord(scannedAt time.Time) ScanRecord {
+	return ScanRecord{
+		Registry:           "docker.io",
+		Repository:         "library/app",
+		RequestedReference: "library/app:latest",
+		ResolvedReference:  "docker.io/library/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		RequestedDigest:    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Mode:               "reference",
+		ScannedAt:          scannedAt.UTC(),
+		Tags: []TagRecord{
+			{
+				Name:           "latest",
+				RootDigest:     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				ManifestDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				Platform:       manifest.Platform{OS: "linux", Architecture: "amd64"},
+				Status:         "scanned",
+			},
+		},
+		Targets: []TargetRecord{
+			{
+				Reference:       "docker.io/library/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				RequestedDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Tags:            []string{"latest"},
+				Manifests: []ManifestRecord{
+					{
+						Digest:     "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+						RootDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						Platform:   manifest.Platform{OS: "linux", Architecture: "amd64"},
+						Status:     "scanned",
+					},
+				},
+			},
+		},
+		DetailedFindings: []findings.DetailedFinding{
+			{
+				Finding: findings.Finding{
+					DetectorName:        "github_token",
+					Confidence:          "high",
+					SourceType:          findings.SourceTypeEnv,
+					ManifestDigest:      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					Platform:            manifest.Platform{OS: "linux", Architecture: "amd64"},
+					Key:                 "GH_TOKEN",
+					RedactedValue:       "ghp********************************56",
+					Fingerprint:         "fingerprint-one",
+					ContextSnippet:      "GH_TOKEN=ghp********************************56",
+					PresentInFinalImage: true,
+				},
+				Value:          "ghp_123456789012345678901234567890123456",
+				RawSnippet:     "GH_TOKEN=ghp_123456789012345678901234567890123456",
+				SourceLocation: "env:GH_TOKEN",
+				MatchStart:     9,
+				MatchEnd:       49,
+			},
+			{
+				Finding: findings.Finding{
+					DetectorName:        "github_token",
+					Confidence:          "high",
+					SourceType:          findings.SourceTypeLabel,
+					ManifestDigest:      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					Platform:            manifest.Platform{OS: "linux", Architecture: "amd64"},
+					Key:                 "token",
+					RedactedValue:       "ghp********************************56",
+					Fingerprint:         "fingerprint-one",
+					ContextSnippet:      "token=ghp********************************56",
+					PresentInFinalImage: true,
+				},
+				Value:          "ghp_123456789012345678901234567890123456",
+				RawSnippet:     "token=ghp_123456789012345678901234567890123456",
+				SourceLocation: "label:token",
+				MatchStart:     6,
+				MatchEnd:       46,
+			},
+		},
+	}
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,6 +1,11 @@
 package storage
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"git.tools.cloudfor.ge/andrew/layerleak/internal/findings"
+)
 
 func TestPostgresConfigValidate(t *testing.T) {
 	tests := []struct {
@@ -13,8 +18,17 @@ func TestPostgresConfigValidate(t *testing.T) {
 			databaseURL: "postgres://postgres:postgres@localhost:5432/layerleak?sslmode=disable",
 		},
 		{
+			name:        "postgresql scheme",
+			databaseURL: "postgresql://postgres:postgres@localhost:5432/layerleak?sslmode=disable",
+		},
+		{
 			name:    "missing",
 			wantErr: true,
+		},
+		{
+			name:        "invalid scheme",
+			databaseURL: "mysql://root@localhost:3306/layerleak",
+			wantErr:     true,
 		},
 	}
 
@@ -25,6 +39,92 @@ func TestPostgresConfigValidate(t *testing.T) {
 			}.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateScanRecord(t *testing.T) {
+	validRecord := func() ScanRecord {
+		return ScanRecord{
+			Registry:   "docker.io",
+			Repository: "library/app",
+			ScannedAt:  time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC),
+			Tags: []TagRecord{
+				{
+					Name:           "latest",
+					RootDigest:     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					ManifestDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					Status:         "scanned",
+				},
+			},
+			Targets: []TargetRecord{
+				{
+					Reference:       "docker.io/library/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					RequestedDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Manifests: []ManifestRecord{
+						{
+							Digest:     "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+							RootDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+							Status:     "scanned",
+						},
+					},
+				},
+			},
+			DetailedFindings: []findings.DetailedFinding{
+				{
+					Finding: findings.Finding{
+						ManifestDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+						Fingerprint:    "fingerprint",
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		record  ScanRecord
+		wantErr bool
+	}{
+		{
+			name:   "valid",
+			record: validRecord(),
+		},
+		{
+			name: "missing repository",
+			record: func() ScanRecord {
+				item := validRecord()
+				item.Repository = ""
+				return item
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "invalid tag status",
+			record: func() ScanRecord {
+				item := validRecord()
+				item.Tags[0].Status = "resolved"
+				return item
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "missing finding fingerprint",
+			record: func() ScanRecord {
+				item := validRecord()
+				item.DetailedFindings[0].Fingerprint = ""
+				return item
+			}(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateScanRecord(tt.record)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateScanRecord() error = %v", err)
 			}
 		})
 	}

--- a/migrations/0001_initial.down.sql
+++ b/migrations/0001_initial.down.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS finding_occurrences;
+DROP TABLE IF EXISTS findings;
+DROP TABLE IF EXISTS tags;
+DROP TABLE IF EXISTS repository_manifests;
+DROP TABLE IF EXISTS manifests;
+DROP TABLE IF EXISTS repositories;

--- a/migrations/0001_initial.up.sql
+++ b/migrations/0001_initial.up.sql
@@ -1,0 +1,114 @@
+CREATE TABLE repositories (
+    id BIGSERIAL PRIMARY KEY,
+    registry TEXT NOT NULL,
+    repository TEXT NOT NULL,
+    first_seen_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    UNIQUE (registry, repository)
+);
+
+CREATE TABLE manifests (
+    digest TEXT PRIMARY KEY,
+    platform_os TEXT NOT NULL DEFAULT '',
+    platform_architecture TEXT NOT NULL DEFAULT '',
+    platform_variant TEXT NOT NULL DEFAULT '',
+    first_seen_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    last_scan_status TEXT NOT NULL,
+    last_scan_error TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX manifests_platform_idx
+    ON manifests (platform_os, platform_architecture, platform_variant);
+
+CREATE TABLE repository_manifests (
+    repository_id BIGINT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    manifest_digest TEXT NOT NULL REFERENCES manifests(digest) ON DELETE CASCADE,
+    root_digest TEXT NOT NULL DEFAULT '',
+    first_seen_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    last_scan_status TEXT NOT NULL,
+    last_scan_error TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (repository_id, manifest_digest)
+);
+
+CREATE INDEX repository_manifests_root_digest_idx
+    ON repository_manifests (repository_id, root_digest);
+
+CREATE TABLE tags (
+    repository_id BIGINT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    tag TEXT NOT NULL,
+    manifest_digest TEXT NOT NULL DEFAULT '',
+    root_digest TEXT NOT NULL DEFAULT '',
+    platform_os TEXT NOT NULL DEFAULT '',
+    platform_architecture TEXT NOT NULL DEFAULT '',
+    platform_variant TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL,
+    error TEXT NOT NULL DEFAULT '',
+    first_seen_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (repository_id, tag, manifest_digest, platform_os, platform_architecture, platform_variant)
+);
+
+CREATE INDEX tags_repository_manifest_idx
+    ON tags (repository_id, manifest_digest);
+
+CREATE TABLE findings (
+    id BIGSERIAL PRIMARY KEY,
+    manifest_digest TEXT NOT NULL REFERENCES manifests(digest) ON DELETE CASCADE,
+    fingerprint TEXT NOT NULL,
+    redacted_value TEXT NOT NULL,
+    value TEXT NOT NULL,
+    first_seen_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    UNIQUE (manifest_digest, fingerprint)
+);
+
+CREATE INDEX findings_fingerprint_idx
+    ON findings (fingerprint);
+
+CREATE TABLE finding_occurrences (
+    id BIGSERIAL PRIMARY KEY,
+    finding_id BIGINT NOT NULL REFERENCES findings(id) ON DELETE CASCADE,
+    detector_name TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    platform_os TEXT NOT NULL DEFAULT '',
+    platform_architecture TEXT NOT NULL DEFAULT '',
+    platform_variant TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL DEFAULT '',
+    layer_digest TEXT NOT NULL DEFAULT '',
+    source_key TEXT NOT NULL DEFAULT '',
+    context_snippet TEXT NOT NULL DEFAULT '',
+    raw_snippet TEXT NOT NULL DEFAULT '',
+    source_location TEXT NOT NULL DEFAULT '',
+    match_start INTEGER NOT NULL DEFAULT 0,
+    match_end INTEGER NOT NULL DEFAULT 0,
+    present_in_final_image BOOLEAN NOT NULL,
+    first_seen_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    UNIQUE (
+        finding_id,
+        detector_name,
+        confidence,
+        source_type,
+        platform_os,
+        platform_architecture,
+        platform_variant,
+        file_path,
+        layer_digest,
+        source_key,
+        context_snippet,
+        raw_snippet,
+        source_location,
+        match_start,
+        match_end,
+        present_in_final_image
+    )
+);
+
+CREATE INDEX finding_occurrences_finding_idx
+    ON finding_occurrences (finding_id);
+
+CREATE INDEX finding_occurrences_source_idx
+    ON finding_occurrences (source_type, file_path, layer_digest);


### PR DESCRIPTION
- The main changes are in migrations/0001_initial.up.sql, internal/storage/postgres.go, and cmd/scanner/storage.go. The schema now covers repositories, tags, manifests, findings, and finding_occurrences; ScanRecord was expanded to represent repository scans, multi-arch targets, tag mappings, and raw DetailedFinding data; and the CLI now initializes a Postgres store from LAYERLEAK_DATABASE_URL, persists scans transactionally, and fails closed if DB init or save fails. I also updated README.md with manual migration usage, Postgres behavior, and secret-safe purge guidance.

- Tests were added for storage validation, CLI/store selection, result-to-record mapping, strict DB failure behavior, and DB-backed persistence helpers in internal/storage/storage_integration_test.go.