### PR TITLE
- More reliably deduped based off their literal context snippet, not on fingerprint and not on the redacted public snippet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for development and contribution guidel
 - Manifest-aware and layer-aware scanning
 - Scans final filesystem and deleted-layer artifacts
 - Scans image config metadata, env vars, labels, and history
-- Deduplicates findings by secret fingerprint
+- Deduplicates findings by secret fingerprint and collapses repeated identical context snippets per manifest
 
 
 ## This project will:
@@ -35,6 +35,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for development and contribution guidel
 - Detect likely secrets using structured, contextual, and file-aware detectors
 - Include the upstream TruffleHog default git-source detector catalog alongside local file-aware and entropy detectors
 - Redact secrets in output and persist only stable fingerprints for deduplication
+- Skip file-backed findings under `test/` and `tests/` directories
 - Provide a CLI-first workflow, then an API and UI
 
 ## How to install
@@ -92,7 +93,7 @@ Operational defaults:
 - Migrations are expected to remain additive.
 - The schema keeps current deduplicated state with `first_seen_at` and `last_seen_at`; it does not keep a `scan_runs` history table yet.
 - Tag mappings are refreshed for tags touched by the current scan.
-- Findings are deduplicated canonically by `(manifest_digest, fingerprint)` and per-location provenance is stored separately.
+- Findings are deduplicated canonically by `(manifest_digest, fingerprint)`, and repeated identical context snippets are collapsed before persistence.
 
 Secret-safety note:
 

--- a/cmd/scanner/storage_test.go
+++ b/cmd/scanner/storage_test.go
@@ -191,6 +191,64 @@ func TestBuildScanRecordCreatesFailedManifestForFailedTarget(t *testing.T) {
 	}
 }
 
+func TestBuildScanRecordDeduplicatesIdenticalRawSnippets(t *testing.T) {
+	record := buildScanRecord(manifest.Reference{
+		Registry:   "docker.io",
+		Repository: "library/app",
+		Original:   "library/app:latest",
+		Tag:        "latest",
+	}, jobs.Result{
+		RequestedReference: "library/app:latest",
+		Repository:         "library/app",
+		Mode:               "reference",
+		DetailedFindings: []findings.DetailedFinding{
+			{
+				Finding: findings.Finding{
+					DetectorName:   "github_token",
+					Confidence:     "high",
+					SourceType:     findings.SourceTypeFileFinal,
+					ManifestDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Platform:       manifest.Platform{OS: "linux", Architecture: "amd64"},
+					FilePath:       "z.env",
+					RedactedValue:  "ghp********************************56",
+					Fingerprint:    "fingerprint",
+					ContextSnippet: "TOKEN=ghp********************************56",
+				},
+				Value:          "ghp_123456789012345678901234567890123456",
+				RawSnippet:     "TOKEN=ghp_123456789012345678901234567890123456",
+				SourceLocation: "file:z.env",
+				MatchStart:     6,
+				MatchEnd:       46,
+			},
+			{
+				Finding: findings.Finding{
+					DetectorName:   "github_token",
+					Confidence:     "high",
+					SourceType:     findings.SourceTypeFileFinal,
+					ManifestDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Platform:       manifest.Platform{OS: "linux", Architecture: "amd64"},
+					FilePath:       "a.env",
+					RedactedValue:  "ghp********************************56",
+					Fingerprint:    "fingerprint",
+					ContextSnippet: "TOKEN=ghp********************************56",
+				},
+				Value:          "ghp_123456789012345678901234567890123456",
+				RawSnippet:     "TOKEN=ghp_123456789012345678901234567890123456",
+				SourceLocation: "file:a.env",
+				MatchStart:     6,
+				MatchEnd:       46,
+			},
+		},
+	}, time.Now().UTC())
+
+	if len(record.DetailedFindings) != 1 {
+		t.Fatalf("len(record.DetailedFindings) = %d", len(record.DetailedFindings))
+	}
+	if record.DetailedFindings[0].FilePath != "a.env" {
+		t.Fatalf("record.DetailedFindings[0].FilePath = %q", record.DetailedFindings[0].FilePath)
+	}
+}
+
 func testDetailedFindingForManifest(manifestDigest string, platform manifest.Platform) findings.DetailedFinding {
 	return findings.DetailedFinding{
 		Finding: findings.Finding{

--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"path"
 	"slices"
 	"strings"
 
@@ -58,54 +59,19 @@ type DetailedFinding struct {
 }
 
 func Deduplicate(items []Finding) []Finding {
-	deduped := make([]Finding, 0, len(items))
+	sorted := slices.Clone(items)
+	slices.SortFunc(sorted, compareFindings)
+
+	deduped := make([]Finding, 0, len(sorted))
 	seen := make(map[string]struct{})
-	for _, item := range items {
-		key := strings.Join([]string{
-			item.DetectorName,
-			item.Confidence,
-			string(item.SourceType),
-			item.ManifestDigest,
-			item.Platform.String(),
-			item.FilePath,
-			item.LayerDigest,
-			item.Key,
-			item.RedactedValue,
-			item.Fingerprint,
-			item.ContextSnippet,
-			boolString(item.PresentInFinalImage),
-		}, "|")
+	for _, item := range sorted {
+		key := findingSnippetDedupKey(item)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
 		deduped = append(deduped, item)
 	}
-
-	slices.SortFunc(deduped, func(left, right Finding) int {
-		if value := strings.Compare(left.ManifestDigest, right.ManifestDigest); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.Platform.String(), right.Platform.String()); value != 0 {
-			return value
-		}
-		if value := strings.Compare(string(left.SourceType), string(right.SourceType)); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.FilePath, right.FilePath); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.LayerDigest, right.LayerDigest); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.DetectorName, right.DetectorName); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.Fingerprint, right.Fingerprint); value != 0 {
-			return value
-		}
-		return strings.Compare(left.Key, right.Key)
-	})
 
 	return deduped
 }
@@ -171,62 +137,19 @@ func (d DetailedFinding) PublicFinding() Finding {
 }
 
 func DeduplicateDetailed(items []DetailedFinding) []DetailedFinding {
-	deduped := make([]DetailedFinding, 0, len(items))
+	sorted := slices.Clone(items)
+	slices.SortFunc(sorted, compareDetailedFindings)
+
+	deduped := make([]DetailedFinding, 0, len(sorted))
 	seen := make(map[string]struct{})
-	for _, item := range items {
-		key := strings.Join([]string{
-			item.DetectorName,
-			item.Confidence,
-			string(item.SourceType),
-			item.ManifestDigest,
-			item.Platform.String(),
-			item.FilePath,
-			item.LayerDigest,
-			item.Key,
-			item.RedactedValue,
-			item.Fingerprint,
-			item.ContextSnippet,
-			boolString(item.PresentInFinalImage),
-			item.Value,
-			item.RawSnippet,
-			item.SourceLocation,
-			intString(item.MatchStart),
-			intString(item.MatchEnd),
-		}, "|")
+	for _, item := range sorted {
+		key := detailedFindingSnippetDedupKey(item)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
 		deduped = append(deduped, item)
 	}
-
-	slices.SortFunc(deduped, func(left, right DetailedFinding) int {
-		if value := strings.Compare(left.ManifestDigest, right.ManifestDigest); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.Platform.String(), right.Platform.String()); value != 0 {
-			return value
-		}
-		if value := strings.Compare(string(left.SourceType), string(right.SourceType)); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.FilePath, right.FilePath); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.LayerDigest, right.LayerDigest); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.DetectorName, right.DetectorName); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.Fingerprint, right.Fingerprint); value != 0 {
-			return value
-		}
-		if value := strings.Compare(left.Key, right.Key); value != 0 {
-			return value
-		}
-		return strings.Compare(left.SourceLocation, right.SourceLocation)
-	})
 
 	return deduped
 }
@@ -254,11 +177,39 @@ func Fingerprint(value string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func boolString(value bool) string {
-	if value {
-		return "true"
+func ShouldSuppressFilePath(filePath string) bool {
+	value := strings.TrimSpace(filePath)
+	if value == "" {
+		return false
 	}
-	return "false"
+
+	value = strings.ReplaceAll(value, "\\", "/")
+	value = path.Clean(value)
+	if value == "." || value == "/" {
+		return false
+	}
+
+	parts := strings.Split(value, "/")
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" || part == "." {
+			continue
+		}
+		normalized = append(normalized, part)
+	}
+	if len(normalized) <= 1 {
+		return false
+	}
+
+	for _, part := range normalized[:len(normalized)-1] {
+		switch strings.ToLower(part) {
+		case "test", "tests":
+			return true
+		}
+	}
+
+	return false
 }
 
 func buildContextSnippet(content string, match detectors.Match) string {
@@ -320,11 +271,59 @@ func buildSourceLocation(input Input) string {
 	return string(input.SourceType) + ":" + location
 }
 
-func intString(value int) string {
-	if value == 0 {
-		return "0"
+func findingSnippetDedupKey(item Finding) string {
+	return strings.Join([]string{
+		item.ManifestDigest,
+		firstNonEmpty(item.ContextSnippet, item.Fingerprint),
+	}, "|")
+}
+
+func detailedFindingSnippetDedupKey(item DetailedFinding) string {
+	return strings.Join([]string{
+		item.ManifestDigest,
+		firstNonEmpty(item.RawSnippet, item.ContextSnippet, item.Fingerprint),
+	}, "|")
+}
+
+func compareFindings(left, right Finding) int {
+	if value := strings.Compare(left.ManifestDigest, right.ManifestDigest); value != 0 {
+		return value
 	}
-	return fmt.Sprintf("%d", value)
+	if value := strings.Compare(left.Platform.String(), right.Platform.String()); value != 0 {
+		return value
+	}
+	if value := strings.Compare(string(left.SourceType), string(right.SourceType)); value != 0 {
+		return value
+	}
+	if value := strings.Compare(left.FilePath, right.FilePath); value != 0 {
+		return value
+	}
+	if value := strings.Compare(left.LayerDigest, right.LayerDigest); value != 0 {
+		return value
+	}
+	if value := strings.Compare(left.DetectorName, right.DetectorName); value != 0 {
+		return value
+	}
+	if value := strings.Compare(left.Fingerprint, right.Fingerprint); value != 0 {
+		return value
+	}
+	return strings.Compare(left.Key, right.Key)
+}
+
+func compareDetailedFindings(left, right DetailedFinding) int {
+	if value := compareFindings(left.Finding, right.Finding); value != 0 {
+		return value
+	}
+	return strings.Compare(left.SourceLocation, right.SourceLocation)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func isValidSourceType(value SourceType) bool {

--- a/internal/findings/findings_test.go
+++ b/internal/findings/findings_test.go
@@ -103,33 +103,143 @@ func TestNormalizeDetailed(t *testing.T) {
 	}
 }
 
-func TestDeduplicatePreservesUniqueProvenance(t *testing.T) {
+func TestShouldSuppressFilePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     bool
+	}{
+		{name: "test directory", filePath: "app/test/.env", want: true},
+		{name: "tests directory", filePath: "app/tests/.env", want: true},
+		{name: "case insensitive directory", filePath: "app/Test/.env", want: true},
+		{name: "windows separator", filePath: `app\tests\.env`, want: true},
+		{name: "filename only", filePath: "app_test.go", want: false},
+		{name: "substring only", filePath: "app/latest/.env", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldSuppressFilePath(tt.filePath); got != tt.want {
+				t.Fatalf("ShouldSuppressFilePath(%q) = %t, want %t", tt.filePath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeduplicateDetailedUsesRawSnippetAcrossFilePaths(t *testing.T) {
+	items := []DetailedFinding{
+		testDetailedFinding("z.env", "github_token", "TOKEN=ghp_123456789012345678901234567890123456", "TOKEN=ghp********************************56"),
+		testDetailedFinding("a.env", "github_token", "TOKEN=ghp_123456789012345678901234567890123456", "TOKEN=ghp********************************56"),
+	}
+
+	deduped := DeduplicateDetailed(items)
+	if len(deduped) != 1 {
+		t.Fatalf("len(deduped) = %d", len(deduped))
+	}
+	if deduped[0].FilePath != "a.env" {
+		t.Fatalf("deduped[0].FilePath = %q", deduped[0].FilePath)
+	}
+}
+
+func TestDeduplicateDetailedUsesRawSnippetAcrossDetectors(t *testing.T) {
+	items := []DetailedFinding{
+		testDetailedFinding("app.env", "z_detector", "TOKEN=ghp_123456789012345678901234567890123456", "TOKEN=ghp********************************56"),
+		testDetailedFinding("app.env", "a_detector", "TOKEN=ghp_123456789012345678901234567890123456", "TOKEN=ghp********************************56"),
+	}
+
+	deduped := DeduplicateDetailed(items)
+	if len(deduped) != 1 {
+		t.Fatalf("len(deduped) = %d", len(deduped))
+	}
+	if deduped[0].DetectorName != "a_detector" {
+		t.Fatalf("deduped[0].DetectorName = %q", deduped[0].DetectorName)
+	}
+}
+
+func TestDeduplicateDetailedPreservesDistinctRawSnippetsForSameFingerprint(t *testing.T) {
+	items := []DetailedFinding{
+		testDetailedFinding("app.env", "github_token", "TOKEN=ghp_123456789012345678901234567890123456", "TOKEN=ghp********************************56"),
+		testDetailedFinding("app.env", "github_token", "GH_TOKEN=ghp_123456789012345678901234567890123456", "GH_TOKEN=ghp********************************56"),
+	}
+
+	deduped := DeduplicateDetailed(items)
+	if len(deduped) != 2 {
+		t.Fatalf("len(deduped) = %d", len(deduped))
+	}
+}
+
+func TestDeduplicateUsesContextSnippetAcrossPublicFindings(t *testing.T) {
+	items := []Finding{
+		{
+			DetectorName:   "github_token",
+			SourceType:     SourceTypeFileFinal,
+			ManifestDigest: "sha256:a",
+			FilePath:       "z.env",
+			Fingerprint:    "one",
+			ContextSnippet: "TOKEN=ghp********************************56",
+		},
+		{
+			DetectorName:   "github_token",
+			SourceType:     SourceTypeFileFinal,
+			ManifestDigest: "sha256:a",
+			FilePath:       "a.env",
+			Fingerprint:    "one",
+			ContextSnippet: "TOKEN=ghp********************************56",
+		},
+	}
+
+	deduped := Deduplicate(items)
+	if len(deduped) != 1 {
+		t.Fatalf("len(deduped) = %d", len(deduped))
+	}
+	if deduped[0].FilePath != "a.env" {
+		t.Fatalf("deduped[0].FilePath = %q", deduped[0].FilePath)
+	}
+}
+
+func TestDeduplicatePreservesDistinctContextSnippets(t *testing.T) {
 	items := []Finding{
 		{
 			DetectorName:   "github_token",
 			SourceType:     SourceTypeEnv,
 			ManifestDigest: "sha256:a",
 			Fingerprint:    "one",
-			Key:            "TOKEN",
-		},
-		{
-			DetectorName:   "github_token",
-			SourceType:     SourceTypeEnv,
-			ManifestDigest: "sha256:a",
-			Fingerprint:    "one",
-			Key:            "TOKEN",
+			ContextSnippet: "TOKEN=ghp********************************56",
 		},
 		{
 			DetectorName:   "github_token",
 			SourceType:     SourceTypeLabel,
 			ManifestDigest: "sha256:a",
 			Fingerprint:    "one",
-			Key:            "token",
+			ContextSnippet: "token=ghp********************************56",
 		},
 	}
 
 	deduped := Deduplicate(items)
 	if len(deduped) != 2 {
 		t.Fatalf("len(deduped) = %d", len(deduped))
+	}
+}
+
+func testDetailedFinding(filePath, detectorName, rawSnippet, contextSnippet string) DetailedFinding {
+	return DetailedFinding{
+		Finding: Finding{
+			DetectorName:   detectorName,
+			Confidence:     "high",
+			SourceType:     SourceTypeFileFinal,
+			ManifestDigest: "sha256:a",
+			Platform: manifest.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			},
+			FilePath:       filePath,
+			Fingerprint:    Fingerprint("ghp_123456789012345678901234567890123456"),
+			ContextSnippet: contextSnippet,
+		},
+		Value:          "ghp_123456789012345678901234567890123456",
+		RawSnippet:     rawSnippet,
+		SourceLocation: "file:" + filePath,
+		MatchStart:     6,
+		MatchEnd:       46,
 	}
 }

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -401,7 +401,7 @@ func scanMetadata(detectorSet detectors.Set, manifestDigest string, platform man
 func scanArtifacts(detectorSet detectors.Set, manifestDigest string, platform manifest.Platform, sourceType findings.SourceType, presentInFinalImage bool, artifacts []layers.Artifact) []findings.DetailedFinding {
 	result := make([]findings.DetailedFinding, 0)
 	for _, artifact := range artifacts {
-		if !artifact.Scannable || len(artifact.Content) == 0 {
+		if !artifact.Scannable || len(artifact.Content) == 0 || findings.ShouldSuppressFilePath(artifact.Path) {
 			continue
 		}
 		result = append(result, scanString(detectorSet, findings.Input{

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -232,6 +232,55 @@ func TestScanArtifactsSkipsNonTextArtifacts(t *testing.T) {
 	}
 }
 
+func TestScanArtifactsSkipsSuppressedTestDirectories(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantPath string
+	}{
+		{name: "test directory", path: "app/test/.env"},
+		{name: "tests directory", path: "app/tests/.env"},
+		{name: "case insensitive directory", path: "app/Test/.env"},
+		{name: "filename remains scannable", path: "app/app_test.go", wantPath: "app/app_test.go"},
+		{name: "non test substring remains scannable", path: "app/latest/.env", wantPath: "app/latest/.env"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items := scanArtifacts(
+				detectors.Default(),
+				"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				manifest.Platform{OS: "linux", Architecture: "amd64"},
+				findings.SourceTypeFileFinal,
+				true,
+				[]layers.Artifact{
+					{
+						Path:         tt.path,
+						LayerDigest:  "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+						ContentClass: layers.ContentClassText,
+						Scannable:    true,
+						Content:      []byte("TOKEN=ghp_123456789012345678901234567890123456"),
+					},
+				},
+			)
+
+			if tt.wantPath == "" {
+				if len(items) != 0 {
+					t.Fatalf("len(items) = %d", len(items))
+				}
+				return
+			}
+
+			if len(items) != 1 {
+				t.Fatalf("len(items) = %d", len(items))
+			}
+			if items[0].FilePath != tt.wantPath {
+				t.Fatalf("items[0].FilePath = %q", items[0].FilePath)
+			}
+		})
+	}
+}
+
 func TestScanReturnsUnderlyingManifestFailureWhenAllSelectedManifestsFail(t *testing.T) {
 	manifestDigest := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	configDigest := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"


### PR DESCRIPTION
- If multiple context snippets are the same, only keep 1 entry, so identical snippets in different manifests are still separate findings.

- Test-path suppression is directory-only, case-insensitive, and applies only to file-backed findings.