### PR TITLE
backward-compatible cmd/layerleak entrypoint 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ Run the scanner against a single tag:
 go run ./cmd/scanner scan redis:latest
 ```
 
+The legacy entrypoint `go run ./cmd/layerleak ...` is also supported for backward compatibility.
+
 Run the scanner against an entire public repository:
 
 ```bash

--- a/cmd/layerleak
+++ b/cmd/layerleak
@@ -1,0 +1,1 @@
+scanner


### PR DESCRIPTION
• Added a backward-compatible cmd/layerleak entrypoint as a symlink to the current scanner command at cmd/layerleak, and noted the legacy path in CONTRIBUTING.md. The failure was happening because this repo only had cmd/scanner, so go run ./cmd/layerleak ... had nothing to resolve.