### PR TITLE
Centralize detection policy and create scanner corpus

### DIFF
--- a/internal/detectionpolicy/policy.go
+++ b/internal/detectionpolicy/policy.go
@@ -1,0 +1,292 @@
+package detectionpolicy
+
+import (
+	"encoding/base64"
+	"net/url"
+	"path"
+	"strings"
+	"unicode"
+)
+
+const (
+	ReasonNone               = ""
+	ReasonDiscardEmpty       = "empty_value"
+	ReasonDiscardPlaceholder = "discard_placeholder"
+	ReasonTestPath           = "test_path"
+	ReasonExamplePath        = "example_path"
+	ReasonPlaceholderMarker  = "placeholder_marker"
+	ReasonReservedHost       = "reserved_host"
+	ReasonKnownDummyValue    = "known_dummy_value"
+)
+
+func DiscardReason(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ReasonDiscardEmpty
+	}
+
+	for _, candidate := range discardValueCandidates(trimmed) {
+		if containsDiscardPlaceholder(candidate) {
+			return ReasonDiscardPlaceholder
+		}
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err == nil && shouldDiscardPlaceholderURL(parsed) {
+		return ReasonDiscardPlaceholder
+	}
+
+	return ReasonNone
+}
+
+func ExampleReason(filePath, key, line, value string) string {
+	if TestPathReason(filePath) != ReasonNone {
+		return ReasonTestPath
+	}
+
+	if ExampleFilenameReason(filePath) != ReasonNone {
+		return ReasonExamplePath
+	}
+
+	if hasKnownDummyValueSignal(value) {
+		return ReasonKnownDummyValue
+	}
+
+	if hasPlaceholderMarkerSignal(filePath, key, line, value) {
+		return ReasonPlaceholderMarker
+	}
+
+	weakSignals := 0
+	reason := ReasonNone
+	if hasWeakExamplePathSignal(filePath) {
+		weakSignals++
+		reason = firstReason(reason, ReasonExamplePath)
+	}
+	if hasReservedHostSignal(line) || hasReservedHostSignal(value) {
+		weakSignals++
+		reason = firstReason(reason, ReasonReservedHost)
+	}
+	if hasWeakExampleKeySignal(key) {
+		weakSignals++
+		reason = firstReason(reason, ReasonPlaceholderMarker)
+	}
+
+	if weakSignals >= 2 {
+		return reason
+	}
+
+	return ReasonNone
+}
+
+func TestPathReason(filePath string) string {
+	for _, part := range normalizedPathParts(filePath) {
+		switch part {
+		case "test", "tests", "__tests__", "fixture", "fixtures", "mock", "mocks":
+			return ReasonTestPath
+		}
+	}
+
+	return ReasonNone
+}
+
+func ExampleFilenameReason(filePath string) string {
+	base := strings.ToLower(strings.TrimSpace(path.Base(strings.ReplaceAll(filePath, "\\", "/"))))
+	if base == "" || base == "." || base == "/" {
+		return ReasonNone
+	}
+
+	for _, marker := range []string{".example", ".sample", ".template"} {
+		if strings.Contains(base, marker+".") || strings.HasSuffix(base, marker) {
+			return ReasonExamplePath
+		}
+	}
+
+	return ReasonNone
+}
+
+func normalizedPathParts(filePath string) []string {
+	value := strings.TrimSpace(filePath)
+	if value == "" {
+		return nil
+	}
+
+	value = strings.ReplaceAll(value, "\\", "/")
+	value = path.Clean(value)
+	if value == "." || value == "/" {
+		return nil
+	}
+
+	parts := strings.Split(value, "/")
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part == "" || part == "." {
+			continue
+		}
+		normalized = append(normalized, part)
+	}
+
+	return normalized
+}
+
+func hasWeakExamplePathSignal(filePath string) bool {
+	for _, part := range normalizedPathParts(filePath) {
+		switch part {
+		case "example", "examples", "sample", "samples", "demo", "demos", "doc", "docs":
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasWeakExampleKeySignal(key string) bool {
+	lower := strings.ToLower(strings.TrimSpace(key))
+	return strings.Contains(lower, "example") || strings.Contains(lower, "sample") || strings.Contains(lower, "demo")
+}
+
+func hasPlaceholderMarkerSignal(values ...string) bool {
+	for _, source := range values {
+		lower := strings.ToLower(source)
+		for _, marker := range []string{
+			"placeholder",
+			"dummy",
+			"fake",
+			"changeme",
+			"change_me",
+			"replace_me",
+			"replace-me",
+			"replace this",
+			"your_token_here",
+			"your-token-here",
+			"your_secret_here",
+			"your-secret-here",
+			"example token",
+			"sample token",
+		} {
+			if strings.Contains(lower, marker) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func hasKnownDummyValueSignal(value string) bool {
+	trimmed := strings.Trim(strings.TrimSpace(value), "\"'`")
+	if trimmed == "" {
+		return false
+	}
+
+	lower := strings.ToLower(trimmed)
+	upper := strings.ToUpper(trimmed)
+	if strings.Contains(upper, "EXAMPLE") {
+		return true
+	}
+
+	switch lower {
+	case "changeme", "replace_me", "replace-me", "dummy", "fake", "your_token_here", "your_secret_here":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasReservedHostSignal(value string) bool {
+	lower := strings.ToLower(value)
+	for _, marker := range []string{
+		"example.com",
+		"example.org",
+		"example.net",
+		"localhost",
+		"127.0.0.1",
+		"0.0.0.0",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func firstReason(current, next string) string {
+	if current != ReasonNone {
+		return current
+	}
+
+	return next
+}
+
+func discardValueCandidates(value string) []string {
+	candidates := []string{strings.ToLower(strings.TrimSpace(value))}
+	for _, encoding := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	} {
+		decoded, err := encoding.DecodeString(strings.TrimSpace(value))
+		if err != nil {
+			continue
+		}
+		text := strings.ToLower(strings.TrimSpace(string(decoded)))
+		if text == "" || !isPrintableText(text) {
+			continue
+		}
+		candidates = append(candidates, text)
+	}
+
+	return candidates
+}
+
+func containsDiscardPlaceholder(value string) bool {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	for _, marker := range []string{
+		"foobar",
+		"foo:bar",
+		"user@example.com",
+		"admin@example.com",
+		"test@example.com",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func shouldDiscardPlaceholderURL(parsed *url.URL) bool {
+	if parsed == nil || parsed.User == nil {
+		return false
+	}
+
+	username := strings.ToLower(strings.TrimSpace(parsed.User.Username()))
+	password, _ := parsed.User.Password()
+	password = strings.ToLower(strings.TrimSpace(password))
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+
+	if containsDiscardPlaceholder(username + ":" + password) {
+		return true
+	}
+	if containsDiscardPlaceholder(username + "@" + host) {
+		return true
+	}
+
+	return false
+}
+
+func isPrintableText(value string) bool {
+	for _, r := range value {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		if !unicode.IsPrint(r) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/detectors/detectors.go
+++ b/internal/detectors/detectors.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/brumbelow/layerleak/internal/detectionpolicy"
 )
 
 type Confidence string
@@ -99,7 +101,7 @@ func (s Set) Scan(input ScanInput) []Match {
 
 	filtered := matches[:0]
 	for _, match := range matches {
-		if shouldDiscardMatchValue(match.Value) {
+		if detectionpolicy.DiscardReason(match.Value) != detectionpolicy.ReasonNone {
 			continue
 		}
 		filtered = append(filtered, match)
@@ -213,7 +215,13 @@ func (d pathRegexDetector) Scan(input ScanInput) []Match {
 		return nil
 	}
 	priority := priorityLocal
-	if d.name == "docker_auth_blob" || strings.HasPrefix(d.name, "docker_config_") || d.name == "terraform_cloud_token" {
+	if d.name == "docker_auth_blob" ||
+		strings.HasPrefix(d.name, "docker_config_") ||
+		d.name == "terraform_cloud_token" ||
+		d.name == "npmrc_auth_token" ||
+		d.name == "npmrc_auth" ||
+		d.name == "netrc_password" ||
+		d.name == "pypirc_password" {
 		priority = priorityStructured
 	}
 	return scanRegexMatches(d.name, d.expression, d.group, d.base, priority, d.validator, input)
@@ -748,83 +756,6 @@ func passesEntropy(value string) bool {
 		entropy += -probability * math.Log2(probability)
 	}
 	return entropy >= 3.75
-}
-
-func shouldDiscardMatchValue(value string) bool {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return true
-	}
-
-	for _, candidate := range discardValueCandidates(trimmed) {
-		if containsDiscardPlaceholder(candidate) {
-			return true
-		}
-	}
-
-	parsed, err := url.Parse(trimmed)
-	if err == nil && shouldDiscardPlaceholderURL(parsed) {
-		return true
-	}
-
-	return false
-}
-
-func discardValueCandidates(value string) []string {
-	candidates := []string{strings.ToLower(strings.TrimSpace(value))}
-	for _, encoding := range []*base64.Encoding{
-		base64.StdEncoding,
-		base64.RawStdEncoding,
-		base64.URLEncoding,
-		base64.RawURLEncoding,
-	} {
-		decoded, err := encoding.DecodeString(strings.TrimSpace(value))
-		if err != nil {
-			continue
-		}
-		text := strings.ToLower(strings.TrimSpace(string(decoded)))
-		if text == "" || !isPrintableText(text) {
-			continue
-		}
-		candidates = append(candidates, text)
-	}
-
-	return candidates
-}
-
-func containsDiscardPlaceholder(value string) bool {
-	lower := strings.ToLower(strings.TrimSpace(value))
-	for _, marker := range []string{
-		"foobar",
-		"foo:bar",
-		"user@example.com",
-		"admin@example.com",
-		"test@example.com",
-	} {
-		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-	return false
-}
-
-func shouldDiscardPlaceholderURL(parsed *url.URL) bool {
-	if parsed == nil || parsed.User == nil {
-		return false
-	}
-
-	username := strings.ToLower(strings.TrimSpace(parsed.User.Username()))
-	password, _ := parsed.User.Password()
-	password = strings.ToLower(strings.TrimSpace(password))
-	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
-
-	if containsDiscardPlaceholder(username + ":" + password) {
-		return true
-	}
-	if containsDiscardPlaceholder(username + "@" + host) {
-		return true
-	}
-	return false
 }
 
 func confidenceRank(value Confidence) int {

--- a/internal/findings/classify.go
+++ b/internal/findings/classify.go
@@ -1,180 +1,19 @@
 package findings
 
 import (
-	"path"
 	"strings"
 
+	"github.com/brumbelow/layerleak/internal/detectionpolicy"
 	"github.com/brumbelow/layerleak/internal/detectors"
 )
 
 func Classify(input Input, match detectors.Match) (Disposition, DispositionReason) {
-	if hasTestPathSignal(input.FilePath) {
-		return DispositionExample, DispositionReasonTestPath
+	reason := detectionpolicy.ExampleReason(input.FilePath, input.Key, matchLine(input.Content, match.Start, match.End), match.Value)
+	if reason == detectionpolicy.ReasonNone {
+		return DispositionActionable, DispositionReasonNone
 	}
 
-	if hasExampleFilenameSignal(input.FilePath) {
-		return DispositionExample, DispositionReasonExamplePath
-	}
-
-	line := matchLine(input.Content, match.Start, match.End)
-	if hasKnownDummyValueSignal(match.Value) {
-		return DispositionExample, DispositionReasonKnownDummyValue
-	}
-
-	if hasPlaceholderMarkerSignal(input, line, match.Value) {
-		return DispositionExample, DispositionReasonPlaceholderMarker
-	}
-
-	weakSignals := 0
-	reason := DispositionReasonNone
-	if hasWeakExamplePathSignal(input.FilePath) {
-		weakSignals++
-		reason = firstReason(reason, DispositionReasonExamplePath)
-	}
-	if hasReservedHostSignal(line) || hasReservedHostSignal(match.Value) {
-		weakSignals++
-		reason = firstReason(reason, DispositionReasonReservedHost)
-	}
-	if hasWeakExampleKeySignal(input.Key) {
-		weakSignals++
-		reason = firstReason(reason, DispositionReasonPlaceholderMarker)
-	}
-
-	if weakSignals >= 2 {
-		return DispositionExample, reason
-	}
-
-	return DispositionActionable, DispositionReasonNone
-}
-
-func hasTestPathSignal(filePath string) bool {
-	for _, part := range normalizedPathParts(filePath) {
-		switch part {
-		case "test", "tests", "__tests__", "fixture", "fixtures", "mock", "mocks":
-			return true
-		}
-	}
-	return false
-}
-
-func hasExampleFilenameSignal(filePath string) bool {
-	base := strings.ToLower(strings.TrimSpace(path.Base(strings.ReplaceAll(filePath, "\\", "/"))))
-	if base == "" || base == "." || base == "/" {
-		return false
-	}
-
-	for _, marker := range []string{".example", ".sample", ".template"} {
-		if strings.Contains(base, marker+".") || strings.HasSuffix(base, marker) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func hasWeakExamplePathSignal(filePath string) bool {
-	for _, part := range normalizedPathParts(filePath) {
-		switch part {
-		case "example", "examples", "sample", "samples", "demo", "demos", "doc", "docs":
-			return true
-		}
-	}
-	return false
-}
-
-func hasWeakExampleKeySignal(key string) bool {
-	lower := strings.ToLower(strings.TrimSpace(key))
-	return strings.Contains(lower, "example") || strings.Contains(lower, "sample") || strings.Contains(lower, "demo")
-}
-
-func normalizedPathParts(filePath string) []string {
-	value := strings.TrimSpace(filePath)
-	if value == "" {
-		return nil
-	}
-
-	value = strings.ReplaceAll(value, "\\", "/")
-	value = path.Clean(value)
-	if value == "." || value == "/" {
-		return nil
-	}
-
-	parts := strings.Split(value, "/")
-	normalized := make([]string, 0, len(parts))
-	for _, part := range parts {
-		part = strings.ToLower(strings.TrimSpace(part))
-		if part == "" || part == "." {
-			continue
-		}
-		normalized = append(normalized, part)
-	}
-
-	return normalized
-}
-
-func hasPlaceholderMarkerSignal(input Input, line, value string) bool {
-	for _, source := range []string{input.FilePath, input.Key, line, value} {
-		lower := strings.ToLower(source)
-		for _, marker := range []string{
-			"placeholder",
-			"dummy",
-			"fake",
-			"changeme",
-			"change_me",
-			"replace_me",
-			"replace-me",
-			"replace this",
-			"your_token_here",
-			"your-token-here",
-			"your_secret_here",
-			"your-secret-here",
-			"example token",
-			"sample token",
-		} {
-			if strings.Contains(lower, marker) {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func hasKnownDummyValueSignal(value string) bool {
-	trimmed := strings.Trim(strings.TrimSpace(value), "\"'`")
-	if trimmed == "" {
-		return false
-	}
-
-	lower := strings.ToLower(trimmed)
-	upper := strings.ToUpper(trimmed)
-	if strings.Contains(upper, "EXAMPLE") {
-		return true
-	}
-
-	switch lower {
-	case "changeme", "replace_me", "replace-me", "dummy", "fake", "your_token_here", "your_secret_here":
-		return true
-	default:
-		return false
-	}
-}
-
-func hasReservedHostSignal(value string) bool {
-	lower := strings.ToLower(value)
-	for _, marker := range []string{
-		"example.com",
-		"example.org",
-		"example.net",
-		"localhost",
-		"127.0.0.1",
-		"0.0.0.0",
-	} {
-		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-	return false
+	return DispositionExample, mapDispositionReason(reason)
 }
 
 func matchLine(content string, start, end int) string {
@@ -204,9 +43,19 @@ func matchLine(content string, start, end int) string {
 	return content[lineStart:lineEnd]
 }
 
-func firstReason(current, next DispositionReason) DispositionReason {
-	if current != DispositionReasonNone {
-		return current
+func mapDispositionReason(reason string) DispositionReason {
+	switch reason {
+	case detectionpolicy.ReasonTestPath:
+		return DispositionReasonTestPath
+	case detectionpolicy.ReasonExamplePath:
+		return DispositionReasonExamplePath
+	case detectionpolicy.ReasonPlaceholderMarker:
+		return DispositionReasonPlaceholderMarker
+	case detectionpolicy.ReasonReservedHost:
+		return DispositionReasonReservedHost
+	case detectionpolicy.ReasonKnownDummyValue:
+		return DispositionReasonKnownDummyValue
+	default:
+		return DispositionReasonNone
 	}
-	return next
 }

--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -4,11 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"path"
 	"slices"
 	"strconv"
 	"strings"
 
+	"github.com/brumbelow/layerleak/internal/detectionpolicy"
 	"github.com/brumbelow/layerleak/internal/detectors"
 	"github.com/brumbelow/layerleak/internal/manifest"
 )
@@ -201,38 +201,7 @@ func Fingerprint(value string) string {
 }
 
 func ShouldSuppressFilePath(filePath string) bool {
-	value := strings.TrimSpace(filePath)
-	if value == "" {
-		return false
-	}
-
-	value = strings.ReplaceAll(value, "\\", "/")
-	value = path.Clean(value)
-	if value == "." || value == "/" {
-		return false
-	}
-
-	parts := strings.Split(value, "/")
-	normalized := make([]string, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" || part == "." {
-			continue
-		}
-		normalized = append(normalized, part)
-	}
-	if len(normalized) <= 1 {
-		return false
-	}
-
-	for _, part := range normalized[:len(normalized)-1] {
-		switch strings.ToLower(part) {
-		case "test", "tests":
-			return true
-		}
-	}
-
-	return false
+	return detectionpolicy.TestPathReason(filePath) == detectionpolicy.ReasonTestPath
 }
 
 func buildContextSnippet(content string, match detectors.Match) string {

--- a/internal/scanner/corpus_test.go
+++ b/internal/scanner/corpus_test.go
@@ -1,0 +1,297 @@
+package scanner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/brumbelow/layerleak/internal/detectors"
+	"github.com/brumbelow/layerleak/internal/findings"
+	"github.com/brumbelow/layerleak/internal/layers"
+	"github.com/brumbelow/layerleak/internal/manifest"
+)
+
+const (
+	corpusOutcomeActionable = "actionable"
+	corpusOutcomeSuppressed = "suppressed"
+	corpusOutcomeDiscarded  = "discarded"
+)
+
+var (
+	corpusManifestDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	corpusLayerDigest    = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	corpusPlatform       = manifest.Platform{OS: "linux", Architecture: "amd64"}
+)
+
+type corpusCase struct {
+	Name                    string               `json:"name"`
+	SourceType              findings.SourceType  `json:"source_type"`
+	Path                    string               `json:"path"`
+	Key                     string               `json:"key"`
+	Content                 string               `json:"content"`
+	ExpectedOutcome         string               `json:"expected_outcome"`
+	ExpectedDetectors       []string             `json:"expected_detectors"`
+	ExpectedConfidenceFloor detectors.Confidence `json:"expected_confidence_floor"`
+	ExpectedReason          string               `json:"expected_reason"`
+}
+
+type corpusExecution struct {
+	all        []findings.DetailedFinding
+	actionable []findings.DetailedFinding
+	suppressed []findings.DetailedFinding
+	survivors  []findings.DetailedFinding
+	outcome    string
+}
+
+func TestCorpusFixtures(t *testing.T) {
+	cases := loadCorpusCases(t)
+	detectorSet := detectors.Default()
+
+	for _, fixture := range cases {
+		t.Run(fixture.Name, func(t *testing.T) {
+			result := runCorpusCase(t, detectorSet, fixture)
+
+			if result.outcome != fixture.ExpectedOutcome {
+				t.Fatalf("outcome = %q, want %q", result.outcome, fixture.ExpectedOutcome)
+			}
+
+			gotDetectors := detectorNames(result.survivors)
+			wantDetectors := slices.Clone(fixture.ExpectedDetectors)
+			slices.Sort(gotDetectors)
+			slices.Sort(wantDetectors)
+			if !slices.Equal(gotDetectors, wantDetectors) {
+				t.Fatalf("detectors = %v, want %v", gotDetectors, wantDetectors)
+			}
+
+			if fixture.ExpectedOutcome == corpusOutcomeSuppressed {
+				if strings.TrimSpace(fixture.ExpectedReason) == "" {
+					t.Fatal("expected_reason must be set for suppressed fixtures")
+				}
+				for _, item := range result.suppressed {
+					if string(item.DispositionReason) != fixture.ExpectedReason {
+						t.Fatalf("disposition_reason = %q, want %q", item.DispositionReason, fixture.ExpectedReason)
+					}
+				}
+			}
+
+			if fixture.ExpectedConfidenceFloor == "" {
+				return
+			}
+			for _, item := range result.survivors {
+				if confidenceRank(detectors.Confidence(item.Confidence)) < confidenceRank(fixture.ExpectedConfidenceFloor) {
+					t.Fatalf("confidence = %q, want at least %q", item.Confidence, fixture.ExpectedConfidenceFloor)
+				}
+			}
+		})
+	}
+}
+
+func TestCorpusProvenancePreservesDistinctSourceLocations(t *testing.T) {
+	cases := loadCorpusCaseMap(t)
+	detectorSet := detectors.Default()
+
+	left, ok := cases["provenance_env_shared_secret"]
+	if !ok {
+		t.Fatal("missing provenance_env_shared_secret fixture")
+	}
+	right, ok := cases["provenance_deleted_layer_shared_secret"]
+	if !ok {
+		t.Fatal("missing provenance_deleted_layer_shared_secret fixture")
+	}
+
+	leftResult := runCorpusCase(t, detectorSet, left)
+	rightResult := runCorpusCase(t, detectorSet, right)
+	leftFinding := requireFindingByDetector(t, leftResult.actionable, "github_token")
+	rightFinding := requireFindingByDetector(t, rightResult.actionable, "github_token")
+
+	combined := []findings.DetailedFinding{leftFinding, rightFinding}
+	deduped := findings.DeduplicateDetailed(combined)
+	if len(deduped) != 2 {
+		t.Fatalf("len(deduped) = %d", len(deduped))
+	}
+	if deduped[0].Fingerprint != deduped[1].Fingerprint {
+		t.Fatalf("fingerprints differ: %q != %q", deduped[0].Fingerprint, deduped[1].Fingerprint)
+	}
+	if deduped[0].SourceLocation == deduped[1].SourceLocation {
+		t.Fatalf("source locations collapsed: %q", deduped[0].SourceLocation)
+	}
+}
+
+func runCorpusCase(t *testing.T, detectorSet detectors.Set, fixture corpusCase) corpusExecution {
+	t.Helper()
+
+	all := executeCorpusInput(t, detectorSet, fixture)
+	actionable, suppressed := splitDetailedFindings(all)
+
+	result := corpusExecution{
+		all:        all,
+		actionable: actionable,
+		suppressed: suppressed,
+	}
+
+	switch {
+	case len(actionable) == 0 && len(suppressed) == 0:
+		result.outcome = corpusOutcomeDiscarded
+		result.survivors = nil
+	case len(actionable) > 0 && len(suppressed) == 0:
+		result.outcome = corpusOutcomeActionable
+		result.survivors = actionable
+	case len(actionable) == 0 && len(suppressed) > 0:
+		result.outcome = corpusOutcomeSuppressed
+		result.survivors = suppressed
+	default:
+		result.outcome = "mixed"
+		result.survivors = append([]findings.DetailedFinding{}, actionable...)
+		result.survivors = append(result.survivors, suppressed...)
+	}
+
+	return result
+}
+
+func executeCorpusInput(t *testing.T, detectorSet detectors.Set, fixture corpusCase) []findings.DetailedFinding {
+	t.Helper()
+
+	switch fixture.SourceType {
+	case findings.SourceTypeFileFinal, findings.SourceTypeFileDeletedLayer:
+		return scanArtifacts(
+			detectorSet,
+			corpusManifestDigest,
+			corpusPlatform,
+			fixture.SourceType,
+			fixture.SourceType == findings.SourceTypeFileFinal,
+			[]layers.Artifact{
+				{
+					Path:         fixture.Path,
+					LayerDigest:  corpusLayerDigest,
+					ContentClass: layers.ContentClassText,
+					Scannable:    true,
+					Content:      []byte(fixture.Content),
+				},
+			},
+		)
+	case findings.SourceTypeEnv, findings.SourceTypeLabel, findings.SourceTypeHistory, findings.SourceTypeConfig:
+		return scanString(detectorSet, findings.Input{
+			ManifestDigest: corpusManifestDigest,
+			Platform:       corpusPlatform,
+			SourceType:     fixture.SourceType,
+			FilePath:       fixture.Path,
+			Key:            fixture.Key,
+			Content:        fixture.Content,
+		}, detectors.ScanInput{
+			Content: fixture.Content,
+			Path:    fixture.Path,
+			Key:     fixture.Key,
+		})
+	default:
+		t.Fatalf("unsupported source_type %q", fixture.SourceType)
+		return nil
+	}
+}
+
+func loadCorpusCases(t *testing.T) []corpusCase {
+	t.Helper()
+
+	root := filepath.Join("testdata", "corpus")
+	paths := make([]string, 0)
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkDir(%q) error = %v", root, err)
+	}
+	slices.Sort(paths)
+
+	cases := make([]corpusCase, 0, len(paths))
+	seenNames := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+
+		var fixture corpusCase
+		if err := json.Unmarshal(body, &fixture); err != nil {
+			t.Fatalf("Unmarshal(%q) error = %v", path, err)
+		}
+		validateCorpusCase(t, path, fixture)
+		if _, ok := seenNames[fixture.Name]; ok {
+			t.Fatalf("duplicate corpus fixture name %q", fixture.Name)
+		}
+		seenNames[fixture.Name] = struct{}{}
+		cases = append(cases, fixture)
+	}
+
+	return cases
+}
+
+func loadCorpusCaseMap(t *testing.T) map[string]corpusCase {
+	t.Helper()
+
+	fixtures := loadCorpusCases(t)
+	indexed := make(map[string]corpusCase, len(fixtures))
+	for _, fixture := range fixtures {
+		indexed[fixture.Name] = fixture
+	}
+
+	return indexed
+}
+
+func validateCorpusCase(t *testing.T, path string, fixture corpusCase) {
+	t.Helper()
+
+	if strings.TrimSpace(fixture.Name) == "" {
+		t.Fatalf("%s: name is required", path)
+	}
+	if fixture.SourceType == "" {
+		t.Fatalf("%s: source_type is required", path)
+	}
+	switch fixture.ExpectedOutcome {
+	case corpusOutcomeActionable, corpusOutcomeSuppressed, corpusOutcomeDiscarded:
+	default:
+		t.Fatalf("%s: unexpected expected_outcome %q", path, fixture.ExpectedOutcome)
+	}
+}
+
+func detectorNames(items []findings.DetailedFinding) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.DetectorName)
+	}
+
+	return names
+}
+
+func confidenceRank(value detectors.Confidence) int {
+	switch value {
+	case detectors.ConfidenceHigh:
+		return 3
+	case detectors.ConfidenceMedium:
+		return 2
+	case detectors.ConfidenceLow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func requireFindingByDetector(t *testing.T, items []findings.DetailedFinding, detectorName string) findings.DetailedFinding {
+	t.Helper()
+
+	for _, item := range items {
+		if item.DetectorName == detectorName {
+			return item
+		}
+	}
+
+	t.Fatalf("missing detector %q in %#v", detectorName, items)
+	return findings.DetailedFinding{}
+}

--- a/internal/scanner/testdata/corpus/discarded_placeholders/basic_auth_url_foo_bar.json
+++ b/internal/scanner/testdata/corpus/discarded_placeholders/basic_auth_url_foo_bar.json
@@ -1,0 +1,11 @@
+{
+  "name": "discarded_basic_auth_url_foo_bar",
+  "source_type": "config",
+  "path": "",
+  "key": "config.working_dir",
+  "content": "https://foo:bar@example.com/config",
+  "expected_outcome": "discarded",
+  "expected_detectors": [],
+  "expected_confidence_floor": "",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/discarded_placeholders/docker_auth_foo_bar.json
+++ b/internal/scanner/testdata/corpus/discarded_placeholders/docker_auth_foo_bar.json
@@ -1,0 +1,11 @@
+{
+  "name": "discarded_docker_auth_foo_bar",
+  "source_type": "file_final",
+  "path": "root/.docker/config.json",
+  "key": "",
+  "content": "{\"auth\":\"Zm9vOmJhcg==\"}",
+  "expected_outcome": "discarded",
+  "expected_detectors": [],
+  "expected_confidence_floor": "",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/discarded_placeholders/docker_auth_user_example.json
+++ b/internal/scanner/testdata/corpus/discarded_placeholders/docker_auth_user_example.json
@@ -1,0 +1,11 @@
+{
+  "name": "discarded_docker_auth_user_example",
+  "source_type": "file_final",
+  "path": "root/.docker/config.json",
+  "key": "",
+  "content": "{\"auth\":\"dXNlckBleGFtcGxlLmNvbTpzdXBlcnNlY3JldA==\"}",
+  "expected_outcome": "discarded",
+  "expected_detectors": [],
+  "expected_confidence_floor": "",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/discarded_placeholders/netrc_foobar.json
+++ b/internal/scanner/testdata/corpus/discarded_placeholders/netrc_foobar.json
@@ -1,0 +1,11 @@
+{
+  "name": "discarded_netrc_foobar",
+  "source_type": "file_final",
+  "path": "root/.netrc",
+  "key": "",
+  "content": "machine example.com login deploy password foobar",
+  "expected_outcome": "discarded",
+  "expected_detectors": [],
+  "expected_confidence_floor": "",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/discarded_placeholders/npmrc_auth_foo_bar.json
+++ b/internal/scanner/testdata/corpus/discarded_placeholders/npmrc_auth_foo_bar.json
@@ -1,0 +1,11 @@
+{
+  "name": "discarded_npmrc_auth_foo_bar",
+  "source_type": "file_final",
+  "path": "root/.npmrc",
+  "key": "",
+  "content": "//registry.npmjs.org/:_auth=Zm9vOmJhcg==",
+  "expected_outcome": "discarded",
+  "expected_detectors": [],
+  "expected_confidence_floor": "",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/overlap_precedence/aws_shared_credentials_precedence.json
+++ b/internal/scanner/testdata/corpus/overlap_precedence/aws_shared_credentials_precedence.json
@@ -1,0 +1,11 @@
+{
+  "name": "precedence_aws_shared_credentials",
+  "source_type": "file_final",
+  "path": "root/.aws/credentials",
+  "key": "",
+  "content": "[default]\naws_access_key_id = AKIA1234567890ABCDEF\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYDkPqLmNsTu\n",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["aws", "aws_shared_credentials_access_key_id", "aws_shared_credentials_secret_access_key"],
+  "expected_confidence_floor": "high",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/overlap_precedence/docker_auth_beats_entropy.json
+++ b/internal/scanner/testdata/corpus/overlap_precedence/docker_auth_beats_entropy.json
@@ -1,0 +1,11 @@
+{
+  "name": "precedence_docker_auth_beats_entropy",
+  "source_type": "file_final",
+  "path": "root/.docker/config.json",
+  "key": "",
+  "content": "{\"auth\":\"cmVhbHVzZXI6U3VwZXJTZWNyZXQxMjM0NQ==\"}",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["docker_auth_blob"],
+  "expected_confidence_floor": "high",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/overlap_precedence/npmrc_auth_token_beats_generic_and_trufflehog.json
+++ b/internal/scanner/testdata/corpus/overlap_precedence/npmrc_auth_token_beats_generic_and_trufflehog.json
@@ -1,0 +1,11 @@
+{
+  "name": "precedence_npmrc_auth_token",
+  "source_type": "file_final",
+  "path": "root/.npmrc",
+  "key": "",
+  "content": "//registry.npmjs.org/:_authToken=npm_123456789012345678901234567890123456",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["npmrc_auth_token"],
+  "expected_confidence_floor": "high",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/overlap_precedence/terraform_beats_entropy.json
+++ b/internal/scanner/testdata/corpus/overlap_precedence/terraform_beats_entropy.json
@@ -1,0 +1,11 @@
+{
+  "name": "precedence_terraform_beats_entropy",
+  "source_type": "file_final",
+  "path": "root/.terraformrc",
+  "key": "",
+  "content": "credentials \"app.terraform.io\" {\n  token = \"atlasv1.1234567890abcdefghijklmnopqrstuv\"\n}",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["terraform_cloud_token"],
+  "expected_confidence_floor": "high",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/real_positives/config_basic_auth_url_actionable.json
+++ b/internal/scanner/testdata/corpus/real_positives/config_basic_auth_url_actionable.json
@@ -1,0 +1,11 @@
+{
+  "name": "config_basic_auth_url_actionable",
+  "source_type": "config",
+  "path": "",
+  "key": "config.working_dir",
+  "content": "https://builder:realpass123@registry.internal/app",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["basic_auth_url", "uri"],
+  "expected_confidence_floor": "medium",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/real_positives/file_deleted_git_credentials_actionable.json
+++ b/internal/scanner/testdata/corpus/real_positives/file_deleted_git_credentials_actionable.json
@@ -1,0 +1,11 @@
+{
+  "name": "file_deleted_git_credentials_actionable",
+  "source_type": "file_deleted_layer",
+  "path": "root/.git-credentials",
+  "key": "",
+  "content": "https://deploy:supersecretvalue@github.com/org/repo.git\n",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["basic_auth_url", "git_credentials_password", "uri"],
+  "expected_confidence_floor": "high",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/real_positives/history_github_token_actionable.json
+++ b/internal/scanner/testdata/corpus/real_positives/history_github_token_actionable.json
@@ -1,0 +1,11 @@
+{
+  "name": "history_github_token_actionable",
+  "source_type": "history",
+  "path": "",
+  "key": "history[0].created_by",
+  "content": "RUN export GH_TOKEN=ghp_123456789012345678901234567890123456",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["github_token"],
+  "expected_confidence_floor": "high",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/real_positives/provenance_deleted_layer_shared_secret.json
+++ b/internal/scanner/testdata/corpus/real_positives/provenance_deleted_layer_shared_secret.json
@@ -1,0 +1,11 @@
+{
+  "name": "provenance_deleted_layer_shared_secret",
+  "source_type": "file_deleted_layer",
+  "path": "app/.env",
+  "key": "",
+  "content": "GH_TOKEN=ghp_123456789012345678901234567890123456",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["github_token"],
+  "expected_confidence_floor": "high",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/real_positives/provenance_env_shared_secret.json
+++ b/internal/scanner/testdata/corpus/real_positives/provenance_env_shared_secret.json
@@ -1,0 +1,11 @@
+{
+  "name": "provenance_env_shared_secret",
+  "source_type": "env",
+  "path": "",
+  "key": "GH_TOKEN",
+  "content": "GH_TOKEN=ghp_123456789012345678901234567890123456",
+  "expected_outcome": "actionable",
+  "expected_detectors": ["github_token", "keyword_entropy"],
+  "expected_confidence_floor": "high",
+  "expected_reason": ""
+}

--- a/internal/scanner/testdata/corpus/suppressed_examples/docs_reserved_host_basic_auth.json
+++ b/internal/scanner/testdata/corpus/suppressed_examples/docs_reserved_host_basic_auth.json
@@ -1,0 +1,11 @@
+{
+  "name": "suppressed_docs_reserved_host_basic_auth",
+  "source_type": "file_final",
+  "path": "docs/setup.env",
+  "key": "",
+  "content": "REGISTRY_URL=https://deploy:supersecretvalue@localhost/org/repo.git",
+  "expected_outcome": "suppressed",
+  "expected_detectors": ["basic_auth_url", "uri"],
+  "expected_confidence_floor": "medium",
+  "expected_reason": "example_path"
+}

--- a/internal/scanner/testdata/corpus/suppressed_examples/example_filename_github_token.json
+++ b/internal/scanner/testdata/corpus/suppressed_examples/example_filename_github_token.json
@@ -1,0 +1,11 @@
+{
+  "name": "suppressed_example_filename_github_token",
+  "source_type": "file_final",
+  "path": "config/.env.example",
+  "key": "",
+  "content": "GH_TOKEN=ghp_123456789012345678901234567890123456",
+  "expected_outcome": "suppressed",
+  "expected_detectors": ["github_token"],
+  "expected_confidence_floor": "high",
+  "expected_reason": "example_path"
+}

--- a/internal/scanner/testdata/corpus/suppressed_examples/known_dummy_github_token.json
+++ b/internal/scanner/testdata/corpus/suppressed_examples/known_dummy_github_token.json
@@ -1,0 +1,11 @@
+{
+  "name": "suppressed_known_dummy_github_token",
+  "source_type": "env",
+  "path": "",
+  "key": "GITHUB_TOKEN",
+  "content": "GITHUB_TOKEN=ghp_EXAMPLEEXAMPLEEXAMPLEEXAMPLEABCDEFGH",
+  "expected_outcome": "suppressed",
+  "expected_detectors": ["github_token", "keyword_entropy"],
+  "expected_confidence_floor": "high",
+  "expected_reason": "known_dummy_value"
+}

--- a/internal/scanner/testdata/corpus/suppressed_examples/placeholder_marker_git_credentials.json
+++ b/internal/scanner/testdata/corpus/suppressed_examples/placeholder_marker_git_credentials.json
@@ -1,0 +1,11 @@
+{
+  "name": "suppressed_placeholder_marker_git_credentials",
+  "source_type": "file_final",
+  "path": "root/.git-credentials",
+  "key": "",
+  "content": "https://deploy:supersecretvalue@registry.internal/replace-me.git\n",
+  "expected_outcome": "suppressed",
+  "expected_detectors": ["basic_auth_url", "git_credentials_password", "uri"],
+  "expected_confidence_floor": "high",
+  "expected_reason": "placeholder_marker"
+}

--- a/internal/scanner/testdata/corpus/suppressed_examples/test_path_github_token.json
+++ b/internal/scanner/testdata/corpus/suppressed_examples/test_path_github_token.json
@@ -1,0 +1,11 @@
+{
+  "name": "suppressed_test_path_github_token",
+  "source_type": "file_final",
+  "path": "app/tests/.env",
+  "key": "",
+  "content": "GH_TOKEN=ghp_123456789012345678901234567890123456",
+  "expected_outcome": "suppressed",
+  "expected_detectors": ["github_token"],
+  "expected_confidence_floor": "high",
+  "expected_reason": "test_path"
+}


### PR DESCRIPTION
- Added shared policy logic in internal/detectionpolicy/policy.go for discard markers, example/test signals, reserved-host logic, and placeholder/dummy handling.
- Rewired internal/detectors/detectors.go and internal/findings/classify.go to use the shared policy instead of duplicated marker tables.
- Kept findings behavior stable, including DispositionExample for suppressed findings, and made internal/findings/findings.go use the shared test-path rule.
- Added a production-path corpus harness in internal/scanner/corpus_test.go plus JSON fixtures under internal/scanner/testdata/corpus, covering actionable, suppressed, discarded, placeholder, structured-config, overlap, and deleted-layer cases.
- Promoted .npmrc, .netrc, and .pypirc detectors to structured priority so same-span precedence is enforced by the corpus.