### PR TITLE
Add a shared limit-error layer for configured scan limits and preserve partial results

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,20 @@ Result and database configuration:
 ```bash
 export LAYERLEAK_FINDINGS_DIR=findings
 export LAYERLEAK_TAG_PAGE_SIZE=100
+export LAYERLEAK_MAX_MANIFEST_BYTES=0
+export LAYERLEAK_MAX_CONFIG_BYTES=0
+export LAYERLEAK_MAX_REPOSITORY_TAGS=0
+export LAYERLEAK_MAX_REPOSITORY_TARGETS=0
+export LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS=2
 export LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?sslmode=disable
 ```
 
 If `LAYERLEAK_FINDINGS_DIR` is not set, layerleak writes JSON findings files to `findings/` under the repo root.
 Saved findings files contain only detections, including unredacted finding values and unredacted context snippets.
 `LAYERLEAK_TAG_PAGE_SIZE` controls Docker Hub tag-list pagination for repository-wide scans.
+`LAYERLEAK_MAX_MANIFEST_BYTES`, `LAYERLEAK_MAX_CONFIG_BYTES`, `LAYERLEAK_MAX_REPOSITORY_TAGS`, and `LAYERLEAK_MAX_REPOSITORY_TARGETS` are off by default when set to `0`.
+If enabled, those limits fail the scan with a clear error instead of silently truncating work.
+`LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS` controls registry request retries and defaults to `2`.
 If `LAYERLEAK_DATABASE_URL` is set, the scanner also writes the scan to Postgres and fails the command if Postgres is unavailable or the save does not succeed.
 
 Result behavior:
@@ -53,6 +61,7 @@ Result behavior:
 - Actionable findings remain in `findings` and drive the non-zero scan exit status.
 - Likely test/example/demo placeholders are emitted separately as suppressed example findings and do not count toward `total_findings`.
 - Finding records include `disposition`, `disposition_reason`, and `line_number` to make triage and false-positive review easier.
+- If a configured operational limit is exceeded, layerleak still writes and renders the partial results produced before the failure, then exits with status `1` because the scan is incomplete.
 
 ## Postgres persistence
 
@@ -108,7 +117,8 @@ Run a scan against a public Docker Hub image:
 ![cli pic](https://github.com/user-attachments/assets/f1940103-8940-4ffa-a5e0-759f079fd1b7)
 
 
-Every scan writes a JSON findings file to the findings output directory. (Default if not set is `~/findings` OR `layerleak/findings`
+Every scan writes a JSON findings file to the findings output directory.
+If `LAYERLEAK_FINDINGS_DIR` is not set, the default output directory is `findings/` under the repo root.
 
 Those saved findings files contain only finding records, including the exact match value, exact source location, unredacted snippet, disposition metadata, and line number for each finding.
 If Postgres persistence is enabled, the same raw finding material is stored in the `findings` and `finding_occurrences` tables.

--- a/internal/cli/exit.go
+++ b/internal/cli/exit.go
@@ -1,11 +1,12 @@
 package cli
 
 type exitError struct {
-	code int
+	code    int
+	message string
 }
 
 func (e exitError) Error() string {
-	return ""
+	return e.message
 }
 
 func (e exitError) ExitCode() int {

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brumbelow/layerleak/internal/config"
 	"github.com/brumbelow/layerleak/internal/detectors"
 	"github.com/brumbelow/layerleak/internal/jobs"
+	"github.com/brumbelow/layerleak/internal/limits"
 	"github.com/brumbelow/layerleak/internal/manifest"
 	"github.com/brumbelow/layerleak/internal/registry"
 	"github.com/spf13/cobra"
@@ -47,6 +48,8 @@ func newScanCmd() *cobra.Command {
 				HTTPClient: &http.Client{
 					Timeout: cfg.HTTPTimeout,
 				},
+				RequestAttempts:  cfg.RegistryRequestAttempts,
+				MaxManifestBytes: cfg.MaxManifestBytes,
 			})
 			detectorSet := detectors.Default()
 
@@ -79,24 +82,43 @@ func newScanCmd() *cobra.Command {
 			}
 
 			result, err := jobs.Scan(ctx, jobs.Request{
-				Reference:    ref,
-				Platform:     platform,
-				Registry:     registryClient,
-				Detectors:    detectorSet,
-				Logger:       logger,
-				MaxFileBytes: cfg.MaxFileBytes,
-				TagPageSize:  cfg.TagPageSize,
+				Reference:            ref,
+				Platform:             platform,
+				Registry:             registryClient,
+				Detectors:            detectorSet,
+				Logger:               logger,
+				MaxFileBytes:         cfg.MaxFileBytes,
+				MaxConfigBytes:       cfg.MaxConfigBytes,
+				TagPageSize:          cfg.TagPageSize,
+				MaxRepositoryTags:    cfg.MaxRepositoryTags,
+				MaxRepositoryTargets: cfg.MaxRepositoryTargets,
 				Progress: func(update jobs.ProgressUpdate) {
 					_ = progress.UpdateFromJob(update)
 				},
 			})
-			if err != nil {
+			scanErr := err
+			limitExceeded := limits.IsExceeded(scanErr)
+			if scanErr != nil && !limitExceeded {
 				_ = progress.Update(progressSnapshot{
 					repository: ref.Repository,
 					phase:      "Error",
-					message:    err.Error(),
+					message:    scanErr.Error(),
 				})
-				return err
+				return scanErr
+			}
+			if scanErr != nil {
+				_ = progress.Update(progressSnapshot{
+					repository:       ref.Repository,
+					tagsCompleted:    result.TagsResolved,
+					tagsFailed:       result.TagsFailed,
+					tagsTotal:        result.TagsEnumerated,
+					targetsCompleted: result.CompletedTargetCount,
+					targetsFailed:    result.FailedTargetCount,
+					targetsTotal:     result.TargetCount,
+					findingsFound:    result.TotalFindings,
+					phase:            "Error",
+					message:          scanErr.Error(),
+				})
 			}
 
 			scannedAt := time.Now().UTC()
@@ -195,6 +217,9 @@ func newScanCmd() *cobra.Command {
 				return fmt.Errorf("unsupported output format: %s", format)
 			}
 
+			if scanErr != nil {
+				return exitError{code: 1, message: scanErr.Error()}
+			}
 			if result.TotalFindings > 0 {
 				return exitError{code: 2}
 			}

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -157,6 +157,104 @@ func TestScanCommandSanitizesProgressErrors(t *testing.T) {
 	}
 }
 
+func TestScanCommandWritesPartialResultsOnConfiguredLimitError(t *testing.T) {
+	firstManifestDigest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	secondManifestDigest := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	firstConfigDigest := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	secondConfigDigest := "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	indexDigest := "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return commandResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		switch request.URL.Path {
+		case "/v2/library/app/manifests/latest":
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageIndex, []byte(`{
+  "schemaVersion":2,
+  "mediaType":"`+manifest.MediaTypeOCIImageIndex+`",
+  "manifests":[
+    {"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","digest":"`+firstManifestDigest+`","size":1,"platform":{"os":"linux","architecture":"amd64"}},
+    {"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","digest":"`+secondManifestDigest+`","size":1,"platform":{"os":"linux","architecture":"arm64"}}
+  ]
+}`), map[string]string{
+				"Docker-Content-Digest": indexDigest,
+			}), nil
+		case "/v2/library/app/manifests/" + firstManifestDigest:
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+firstConfigDigest+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": firstManifestDigest,
+			}), nil
+		case "/v2/library/app/manifests/" + secondManifestDigest:
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+secondConfigDigest+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": secondManifestDigest,
+			}), nil
+		case "/v2/library/app/blobs/" + firstConfigDigest:
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"amd64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"]}}`), nil), nil
+		case "/v2/library/app/blobs/" + secondConfigDigest:
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"arm64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"],"User":"builder","WorkingDir":"https://builder:supersecretvalue@registry.internal/app"}}`), nil), nil
+		default:
+			return commandResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+		}
+	})
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = transport
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+
+	findingsDir := t.TempDir()
+	t.Setenv("LAYERLEAK_REGISTRY_BASE_URL", "https://registry.test")
+	t.Setenv("LAYERLEAK_FINDINGS_DIR", findingsDir)
+	t.Setenv("LAYERLEAK_MAX_CONFIG_BYTES", "128")
+
+	command := newRootCmd()
+	var stdout bytes.Buffer
+	command.SetOut(&stdout)
+	command.SetErr(&stdout)
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"scan", "library/app:latest", "--format", "json"})
+
+	err := command.Execute()
+	exit, ok := err.(interface{ ExitCode() int })
+	if !ok {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if exit.ExitCode() != 1 {
+		t.Fatalf("exit.ExitCode() = %d", exit.ExitCode())
+	}
+	if !strings.Contains(err.Error(), "max config bytes limit") {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"total_findings"`) {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+
+	entries, readErr := os.ReadDir(findingsDir)
+	if readErr != nil {
+		t.Fatalf("ReadDir() error = %v", readErr)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d", len(entries))
+	}
+
+	body, readErr := os.ReadFile(findingsDir + string(os.PathSeparator) + entries[0].Name())
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if !strings.Contains(string(body), "ghp_123456789012345678901234567890123456") {
+		t.Fatalf("partial findings file missing raw secret: %q", string(body))
+	}
+}
+
 type roundTripFunc func(request *http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,14 +9,19 @@ import (
 )
 
 type Config struct {
-	LogLevel        string
-	RegistryBaseURL string
-	RegistryAuthURL string
-	HTTPTimeout     time.Duration
-	MaxFileBytes    int64
-	TagPageSize     int
-	FindingsDir     string
-	DatabaseURL     string
+	LogLevel                string
+	RegistryBaseURL         string
+	RegistryAuthURL         string
+	HTTPTimeout             time.Duration
+	MaxFileBytes            int64
+	MaxManifestBytes        int64
+	MaxConfigBytes          int64
+	TagPageSize             int
+	MaxRepositoryTags       int
+	MaxRepositoryTargets    int
+	RegistryRequestAttempts int
+	FindingsDir             string
+	DatabaseURL             string
 }
 
 func Load() (Config, error) {
@@ -28,20 +33,45 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	maxManifestBytes, err := nonNegativeInt64FromEnv("LAYERLEAK_MAX_MANIFEST_BYTES", 0)
+	if err != nil {
+		return Config{}, err
+	}
+	maxConfigBytes, err := nonNegativeInt64FromEnv("LAYERLEAK_MAX_CONFIG_BYTES", 0)
+	if err != nil {
+		return Config{}, err
+	}
 	tagPageSize, err := intFromEnv("LAYERLEAK_TAG_PAGE_SIZE", 100)
+	if err != nil {
+		return Config{}, err
+	}
+	maxRepositoryTags, err := nonNegativeIntFromEnv("LAYERLEAK_MAX_REPOSITORY_TAGS", 0)
+	if err != nil {
+		return Config{}, err
+	}
+	maxRepositoryTargets, err := nonNegativeIntFromEnv("LAYERLEAK_MAX_REPOSITORY_TARGETS", 0)
+	if err != nil {
+		return Config{}, err
+	}
+	registryRequestAttempts, err := intFromEnv("LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS", 2)
 	if err != nil {
 		return Config{}, err
 	}
 
 	return Config{
-		LogLevel:        envOrDefault("LAYERLEAK_LOG_LEVEL", "info"),
-		RegistryBaseURL: envOrDefault("LAYERLEAK_REGISTRY_BASE_URL", "https://registry-1.docker.io"),
-		RegistryAuthURL: envOrDefault("LAYERLEAK_REGISTRY_AUTH_URL", "https://auth.docker.io/token"),
-		HTTPTimeout:     timeout,
-		MaxFileBytes:    maxFileBytes,
-		TagPageSize:     tagPageSize,
-		FindingsDir:     strings.TrimSpace(os.Getenv("LAYERLEAK_FINDINGS_DIR")),
-		DatabaseURL:     strings.TrimSpace(os.Getenv("LAYERLEAK_DATABASE_URL")),
+		LogLevel:                envOrDefault("LAYERLEAK_LOG_LEVEL", "info"),
+		RegistryBaseURL:         envOrDefault("LAYERLEAK_REGISTRY_BASE_URL", "https://registry-1.docker.io"),
+		RegistryAuthURL:         envOrDefault("LAYERLEAK_REGISTRY_AUTH_URL", "https://auth.docker.io/token"),
+		HTTPTimeout:             timeout,
+		MaxFileBytes:            maxFileBytes,
+		MaxManifestBytes:        maxManifestBytes,
+		MaxConfigBytes:          maxConfigBytes,
+		TagPageSize:             tagPageSize,
+		MaxRepositoryTags:       maxRepositoryTags,
+		MaxRepositoryTargets:    maxRepositoryTargets,
+		RegistryRequestAttempts: registryRequestAttempts,
+		FindingsDir:             strings.TrimSpace(os.Getenv("LAYERLEAK_FINDINGS_DIR")),
+		DatabaseURL:             strings.TrimSpace(os.Getenv("LAYERLEAK_DATABASE_URL")),
 	}, nil
 }
 
@@ -97,6 +127,40 @@ func intFromEnv(key string, fallback int) (int, error) {
 	}
 	if parsed <= 0 {
 		return 0, fmt.Errorf("%s must be greater than zero", key)
+	}
+
+	return parsed, nil
+}
+
+func nonNegativeInt64FromEnv(key string, fallback int64) (int64, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("%s must be greater than or equal to zero", key)
+	}
+
+	return parsed, nil
+}
+
+func nonNegativeIntFromEnv(key string, fallback int) (int, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("%s must be greater than or equal to zero", key)
 	}
 
 	return parsed, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,7 +11,12 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("LAYERLEAK_REGISTRY_AUTH_URL", "")
 	t.Setenv("LAYERLEAK_HTTP_TIMEOUT", "")
 	t.Setenv("LAYERLEAK_MAX_FILE_BYTES", "")
+	t.Setenv("LAYERLEAK_MAX_MANIFEST_BYTES", "")
+	t.Setenv("LAYERLEAK_MAX_CONFIG_BYTES", "")
 	t.Setenv("LAYERLEAK_TAG_PAGE_SIZE", "")
+	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TAGS", "")
+	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TARGETS", "")
+	t.Setenv("LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS", "")
 	t.Setenv("LAYERLEAK_FINDINGS_DIR", "")
 	t.Setenv("LAYERLEAK_DATABASE_URL", "")
 
@@ -39,8 +44,23 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.MaxFileBytes != 1<<20 {
 		t.Fatalf("cfg.MaxFileBytes = %d", cfg.MaxFileBytes)
 	}
+	if cfg.MaxManifestBytes != 0 {
+		t.Fatalf("cfg.MaxManifestBytes = %d", cfg.MaxManifestBytes)
+	}
+	if cfg.MaxConfigBytes != 0 {
+		t.Fatalf("cfg.MaxConfigBytes = %d", cfg.MaxConfigBytes)
+	}
 	if cfg.TagPageSize != 100 {
 		t.Fatalf("cfg.TagPageSize = %d", cfg.TagPageSize)
+	}
+	if cfg.MaxRepositoryTags != 0 {
+		t.Fatalf("cfg.MaxRepositoryTags = %d", cfg.MaxRepositoryTags)
+	}
+	if cfg.MaxRepositoryTargets != 0 {
+		t.Fatalf("cfg.MaxRepositoryTargets = %d", cfg.MaxRepositoryTargets)
+	}
+	if cfg.RegistryRequestAttempts != 2 {
+		t.Fatalf("cfg.RegistryRequestAttempts = %d", cfg.RegistryRequestAttempts)
 	}
 
 	if cfg.FindingsDir != "" {
@@ -64,8 +84,63 @@ func TestLoadInvalidMaxFileBytes(t *testing.T) {
 	}
 }
 
+func TestLoadInvalidMaxManifestBytes(t *testing.T) {
+	t.Setenv("LAYERLEAK_MAX_MANIFEST_BYTES", "-1")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
+func TestLoadInvalidMaxConfigBytes(t *testing.T) {
+	t.Setenv("LAYERLEAK_MAX_CONFIG_BYTES", "-1")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
 func TestLoadInvalidTagPageSize(t *testing.T) {
 	t.Setenv("LAYERLEAK_TAG_PAGE_SIZE", "0")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
+func TestLoadAllowsZeroRepositoryLimits(t *testing.T) {
+	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TAGS", "0")
+	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TARGETS", "0")
+	t.Setenv("LAYERLEAK_MAX_MANIFEST_BYTES", "0")
+	t.Setenv("LAYERLEAK_MAX_CONFIG_BYTES", "0")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.MaxRepositoryTags != 0 || cfg.MaxRepositoryTargets != 0 || cfg.MaxManifestBytes != 0 || cfg.MaxConfigBytes != 0 {
+		t.Fatalf("cfg = %#v", cfg)
+	}
+}
+
+func TestLoadInvalidMaxRepositoryTags(t *testing.T) {
+	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TAGS", "-1")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
+func TestLoadInvalidMaxRepositoryTargets(t *testing.T) {
+	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TARGETS", "-1")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
+func TestLoadInvalidRegistryRequestAttempts(t *testing.T) {
+	t.Setenv("LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS", "0")
 
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil")

--- a/internal/jobs/scan.go
+++ b/internal/jobs/scan.go
@@ -9,20 +9,24 @@ import (
 
 	"github.com/brumbelow/layerleak/internal/detectors"
 	"github.com/brumbelow/layerleak/internal/findings"
+	"github.com/brumbelow/layerleak/internal/limits"
 	"github.com/brumbelow/layerleak/internal/manifest"
 	"github.com/brumbelow/layerleak/internal/registry"
 	"github.com/brumbelow/layerleak/internal/scanner"
 )
 
 type Request struct {
-	Reference    manifest.Reference
-	Platform     string
-	Registry     *registry.Client
-	Detectors    detectors.Set
-	Logger       *slog.Logger
-	MaxFileBytes int64
-	TagPageSize  int
-	Progress     ProgressFunc
+	Reference            manifest.Reference
+	Platform             string
+	Registry             *registry.Client
+	Detectors            detectors.Set
+	Logger               *slog.Logger
+	MaxFileBytes         int64
+	MaxConfigBytes       int64
+	TagPageSize          int
+	MaxRepositoryTags    int
+	MaxRepositoryTargets int
+	Progress             ProgressFunc
 }
 
 type ProgressPhase string
@@ -128,10 +132,6 @@ func scanSingleReference(ctx context.Context, request Request) (Result, error) {
 		currentRef:     request.Reference.CanonicalString(""),
 		findingsBefore: 0,
 	})
-	if err != nil {
-		return Result{}, err
-	}
-
 	result := Result{
 		RequestedReference:     request.Reference.Original,
 		Repository:             request.Reference.Repository,
@@ -146,7 +146,7 @@ func scanSingleReference(ctx context.Context, request Request) (Result, error) {
 		CompletedManifestCount: scanResult.CompletedManifestCount,
 		FailedManifestCount:    scanResult.FailedManifestCount,
 		Targets: []TargetResult{
-			targetResultFromScanResult(scanResult, tags),
+			targetResultFromScanResult(request.Reference, scanResult, tags),
 		},
 		Findings:                     scanResult.Findings,
 		DetailedFindings:             scanResult.DetailedFindings,
@@ -157,13 +157,16 @@ func scanSingleReference(ctx context.Context, request Request) (Result, error) {
 		SuppressedFindingsCount:      scanResult.SuppressedFindingsCount,
 		SuppressedUniqueFingerprints: scanResult.SuppressedUniqueFingerprints,
 	}
-	if len(tags) > 0 {
+	if len(tags) > 0 && err == nil {
 		result.TagResults = []TagResult{{
 			Tag:             tags[0],
 			RootDigest:      scanResult.RequestedDigest,
 			TargetReference: scanResult.ResolvedReference,
 			Status:          "scanned",
 		}}
+	}
+	if err != nil {
+		return result, err
 	}
 
 	emitProgress(request, ProgressUpdate{
@@ -181,25 +184,26 @@ func scanSingleReference(ctx context.Context, request Request) (Result, error) {
 }
 
 func scanRepository(ctx context.Context, request Request) (Result, error) {
+	result := Result{
+		RequestedReference: request.Reference.Original,
+		Repository:         request.Reference.Repository,
+		Mode:               "repository",
+		ResolvedReference:  request.Reference.RepositoryString(),
+		TagResults:         make([]TagResult, 0),
+		Targets:            make([]TargetResult, 0),
+	}
+
 	emitProgress(request, ProgressUpdate{
 		Phase:      ProgressPhaseListingTags,
 		Repository: request.Reference.Repository,
 		Message:    "Listing repository tags",
 	})
 
-	tags, err := request.Registry.ListTags(ctx, request.Reference.Repository, request.TagPageSize)
+	tags, err := request.Registry.ListTags(ctx, request.Reference.Repository, request.TagPageSize, request.MaxRepositoryTags)
+	result.TagsEnumerated = len(tags)
 	if err != nil {
-		return Result{}, err
-	}
-
-	result := Result{
-		RequestedReference: request.Reference.Original,
-		Repository:         request.Reference.Repository,
-		Mode:               "repository",
-		ResolvedReference:  request.Reference.RepositoryString(),
-		TagsEnumerated:     len(tags),
-		TagResults:         make([]TagResult, 0, len(tags)),
-		Targets:            make([]TargetResult, 0),
+		finalizeResult(&result, nil, nil)
+		return result, err
 	}
 
 	groups := make(map[string]*targetGroup)
@@ -265,6 +269,11 @@ func scanRepository(ctx context.Context, request Request) (Result, error) {
 	})
 
 	result.TargetCount = len(groupList)
+	if request.MaxRepositoryTargets > 0 && len(groupList) > request.MaxRepositoryTargets {
+		finalizeResult(&result, nil, nil)
+		return result, limits.NewExceeded(limits.KindRepositoryTargets, int64(request.MaxRepositoryTargets), "repository "+request.Reference.Repository)
+	}
+
 	allDetailedFindings := make([]findings.DetailedFinding, 0)
 	allSuppressedDetailedFindings := make([]findings.DetailedFinding, 0)
 	for _, group := range groupList {
@@ -280,13 +289,16 @@ func scanRepository(ctx context.Context, request Request) (Result, error) {
 			currentRef:       scanReference.CanonicalString(""),
 			findingsBefore:   len(allDetailedFindings),
 		})
+		targetResult := targetResultFromScanResult(scanReference, scanResult, group.tags)
 		if err != nil {
-			result.Targets = append(result.Targets, TargetResult{
-				Reference: scanReference.CanonicalString(""),
-				Tags:      slices.Clone(group.tags),
-				Error:     err.Error(),
-			})
+			targetResult.Error = err.Error()
+			result.Targets = append(result.Targets, targetResult)
 			result.FailedTargetCount++
+			result.ManifestCount += scanResult.ManifestCount
+			result.CompletedManifestCount += scanResult.CompletedManifestCount
+			result.FailedManifestCount += scanResult.FailedManifestCount
+			allDetailedFindings = append(allDetailedFindings, scanResult.DetailedFindings...)
+			allSuppressedDetailedFindings = append(allSuppressedDetailedFindings, scanResult.SuppressedDetailedFindings...)
 			emitProgress(request, ProgressUpdate{
 				Phase:            ProgressPhaseTargetFailed,
 				Repository:       request.Reference.Repository,
@@ -301,10 +313,14 @@ func scanRepository(ctx context.Context, request Request) (Result, error) {
 				CurrentReference: scanReference.CanonicalString(""),
 				Message:          err.Error(),
 			})
+			if limits.IsExceeded(err) {
+				finalizeResult(&result, allDetailedFindings, allSuppressedDetailedFindings)
+				return result, err
+			}
 			continue
 		}
 
-		result.Targets = append(result.Targets, targetResultFromScanResult(scanResult, group.tags))
+		result.Targets = append(result.Targets, targetResult)
 		result.CompletedTargetCount++
 		result.ManifestCount += scanResult.ManifestCount
 		result.CompletedManifestCount += scanResult.CompletedManifestCount
@@ -327,25 +343,10 @@ func scanRepository(ctx context.Context, request Request) (Result, error) {
 		})
 	}
 
+	finalizeResult(&result, allDetailedFindings, allSuppressedDetailedFindings)
 	if result.CompletedTargetCount == 0 {
 		return result, allRepositoryTargetsFailedError(result.Targets)
 	}
-
-	result.DetailedFindings = findings.DeduplicateDetailed(allDetailedFindings)
-	result.Findings = make([]findings.Finding, 0, len(result.DetailedFindings))
-	for _, item := range result.DetailedFindings {
-		result.Findings = append(result.Findings, item.PublicFinding())
-	}
-	result.SuppressedDetailedFindings = findings.DeduplicateDetailed(allSuppressedDetailedFindings)
-	result.SuppressedFindings = make([]findings.Finding, 0, len(result.SuppressedDetailedFindings))
-	for _, item := range result.SuppressedDetailedFindings {
-		result.SuppressedFindings = append(result.SuppressedFindings, item.PublicFinding())
-	}
-	result.TotalFindings = len(result.Findings)
-	result.UniqueFingerprints = findings.UniqueFingerprintCount(result.Findings)
-	result.SuppressedFindingsCount = len(result.SuppressedFindings)
-	result.SuppressedUniqueFingerprints = findings.UniqueFingerprintCount(result.SuppressedFindings)
-	sortTargetResults(result.Targets)
 	emitProgress(request, ProgressUpdate{
 		Phase:            ProgressPhaseCompleted,
 		Repository:       request.Reference.Repository,
@@ -376,12 +377,13 @@ type progressState struct {
 
 func scanTarget(ctx context.Context, request Request, reference manifest.Reference, tags []string, state progressState) (scanner.Result, error) {
 	return scanner.Scan(ctx, scanner.Request{
-		Reference:    reference,
-		Platform:     request.Platform,
-		Registry:     request.Registry,
-		Detectors:    request.Detectors,
-		Logger:       request.Logger,
-		MaxFileBytes: request.MaxFileBytes,
+		Reference:      reference,
+		Platform:       request.Platform,
+		Registry:       request.Registry,
+		Detectors:      request.Detectors,
+		Logger:         request.Logger,
+		MaxFileBytes:   request.MaxFileBytes,
+		MaxConfigBytes: request.MaxConfigBytes,
 		Progress: func(update scanner.ProgressUpdate) {
 			emitProgress(request, ProgressUpdate{
 				Phase:                 mapScannerPhase(update.Phase),
@@ -403,9 +405,13 @@ func scanTarget(ctx context.Context, request Request, reference manifest.Referen
 	})
 }
 
-func targetResultFromScanResult(scanResult scanner.Result, tags []string) TargetResult {
+func targetResultFromScanResult(reference manifest.Reference, scanResult scanner.Result, tags []string) TargetResult {
+	referenceValue := scanResult.RequestedReference
+	if strings.TrimSpace(referenceValue) == "" {
+		referenceValue = reference.CanonicalString("")
+	}
 	return TargetResult{
-		Reference:              scanResult.RequestedReference,
+		Reference:              referenceValue,
 		Tags:                   slices.Clone(tags),
 		ResolvedReference:      scanResult.ResolvedReference,
 		RequestedDigest:        scanResult.RequestedDigest,
@@ -462,6 +468,24 @@ func emitProgress(request Request, update ProgressUpdate) {
 	if request.Progress != nil {
 		request.Progress(update)
 	}
+}
+
+func finalizeResult(result *Result, actionable, suppressed []findings.DetailedFinding) {
+	result.DetailedFindings = findings.DeduplicateDetailed(actionable)
+	result.Findings = make([]findings.Finding, 0, len(result.DetailedFindings))
+	for _, item := range result.DetailedFindings {
+		result.Findings = append(result.Findings, item.PublicFinding())
+	}
+	result.SuppressedDetailedFindings = findings.DeduplicateDetailed(suppressed)
+	result.SuppressedFindings = make([]findings.Finding, 0, len(result.SuppressedDetailedFindings))
+	for _, item := range result.SuppressedDetailedFindings {
+		result.SuppressedFindings = append(result.SuppressedFindings, item.PublicFinding())
+	}
+	result.TotalFindings = len(result.Findings)
+	result.UniqueFingerprints = findings.UniqueFingerprintCount(result.Findings)
+	result.SuppressedFindingsCount = len(result.SuppressedFindings)
+	result.SuppressedUniqueFingerprints = findings.UniqueFingerprintCount(result.SuppressedFindings)
+	sortTargetResults(result.Targets)
 }
 
 func allRepositoryTargetsFailedError(items []TargetResult) error {

--- a/internal/jobs/scan_test.go
+++ b/internal/jobs/scan_test.go
@@ -38,24 +38,18 @@ func TestScanRepositoryEnumeratesTagsAndDeduplicatesDigests(t *testing.T) {
 			}), nil
 		case request.URL.Path == "/v2/library/app/tags/list" && request.URL.Query().Get("n") == "2" && request.URL.Query().Get("last") == "2.0":
 			return repoResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["1.0"]}`), nil), nil
-		case request.URL.Path == "/v2/library/app/manifests/latest":
-			if request.Method == http.MethodHead {
-				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
-					"Docker-Content-Digest": digestOne,
-				}), nil
-			}
-		case request.URL.Path == "/v2/library/app/manifests/2.0":
-			if request.Method == http.MethodHead {
-				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
-					"Docker-Content-Digest": digestOne,
-				}), nil
-			}
-		case request.URL.Path == "/v2/library/app/manifests/1.0":
-			if request.Method == http.MethodHead {
-				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
-					"Docker-Content-Digest": digestTwo,
-				}), nil
-			}
+		case request.URL.Path == "/v2/library/app/manifests/latest" && request.Method == http.MethodHead:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+				"Docker-Content-Digest": digestOne,
+			}), nil
+		case request.URL.Path == "/v2/library/app/manifests/2.0" && request.Method == http.MethodHead:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+				"Docker-Content-Digest": digestOne,
+			}), nil
+		case request.URL.Path == "/v2/library/app/manifests/1.0" && request.Method == http.MethodHead:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+				"Docker-Content-Digest": digestTwo,
+			}), nil
 		case request.URL.Path == "/v2/library/app/manifests/"+digestOne:
 			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+configOne+`","size":1},"layers":[]}`), map[string]string{
 				"Docker-Content-Digest": digestOne,
@@ -71,8 +65,6 @@ func TestScanRepositoryEnumeratesTagsAndDeduplicatesDigests(t *testing.T) {
 		default:
 			return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 		}
-
-		return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 	})
 
 	ref, err := manifest.ParseReference("library/app")
@@ -169,8 +161,6 @@ func TestScanRepositoryReturnsUnderlyingTargetErrorWhenAllTargetsFail(t *testing
 		default:
 			return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 		}
-
-		return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 	})
 
 	ref, err := manifest.ParseReference("library/app")
@@ -216,26 +206,20 @@ func TestScanRepositoryReturnsPartialResultWhenTargetLimitExceeded(t *testing.T)
 			}), nil
 		}
 
-		switch request.URL.Path {
-		case "/v2/library/app/tags/list":
+		switch {
+		case request.URL.Path == "/v2/library/app/tags/list":
 			return repoResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["latest","1.0"]}`), nil), nil
-		case "/v2/library/app/manifests/latest":
-			if request.Method == http.MethodHead {
-				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
-					"Docker-Content-Digest": digestOne,
-				}), nil
-			}
-		case "/v2/library/app/manifests/1.0":
-			if request.Method == http.MethodHead {
-				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
-					"Docker-Content-Digest": digestTwo,
-				}), nil
-			}
+		case request.URL.Path == "/v2/library/app/manifests/latest" && request.Method == http.MethodHead:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+				"Docker-Content-Digest": digestOne,
+			}), nil
+		case request.URL.Path == "/v2/library/app/manifests/1.0" && request.Method == http.MethodHead:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+				"Docker-Content-Digest": digestTwo,
+			}), nil
 		default:
 			return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 		}
-
-		return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 	})
 
 	ref, err := manifest.ParseReference("library/app")
@@ -290,38 +274,32 @@ func TestScanRepositoryAbortsOnLimitErrorAndPreservesCompletedTargets(t *testing
 			}), nil
 		}
 
-		switch request.URL.Path {
-		case "/v2/library/app/tags/list":
+		switch {
+		case request.URL.Path == "/v2/library/app/tags/list":
 			return repoResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["1.0","latest"]}`), nil), nil
-		case "/v2/library/app/manifests/1.0":
-			if request.Method == http.MethodHead {
-				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
-					"Docker-Content-Digest": digestOne,
-				}), nil
-			}
-		case "/v2/library/app/manifests/latest":
-			if request.Method == http.MethodHead {
-				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
-					"Docker-Content-Digest": digestTwo,
-				}), nil
-			}
-		case "/v2/library/app/manifests/" + digestOne:
+		case request.URL.Path == "/v2/library/app/manifests/1.0" && request.Method == http.MethodHead:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+				"Docker-Content-Digest": digestOne,
+			}), nil
+		case request.URL.Path == "/v2/library/app/manifests/latest" && request.Method == http.MethodHead:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+				"Docker-Content-Digest": digestTwo,
+			}), nil
+		case request.URL.Path == "/v2/library/app/manifests/"+digestOne:
 			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+configOne+`","size":1},"layers":[]}`), map[string]string{
 				"Docker-Content-Digest": digestOne,
 			}), nil
-		case "/v2/library/app/manifests/" + digestTwo:
+		case request.URL.Path == "/v2/library/app/manifests/"+digestTwo:
 			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+configTwo+`","size":1},"layers":[]}`), map[string]string{
 				"Docker-Content-Digest": digestTwo,
 			}), nil
-		case "/v2/library/app/blobs/" + configOne:
+		case request.URL.Path == "/v2/library/app/blobs/"+configOne:
 			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"amd64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"]}}`), nil), nil
-		case "/v2/library/app/blobs/" + configTwo:
+		case request.URL.Path == "/v2/library/app/blobs/"+configTwo:
 			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"amd64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"],"User":"builder","WorkingDir":"https://builder:supersecretvalue@registry.internal/app"}}`), nil), nil
 		default:
 			return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 		}
-
-		return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 	})
 
 	ref, err := manifest.ParseReference("library/app")

--- a/internal/jobs/scan_test.go
+++ b/internal/jobs/scan_test.go
@@ -169,6 +169,8 @@ func TestScanRepositoryReturnsUnderlyingTargetErrorWhenAllTargetsFail(t *testing
 		default:
 			return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 		}
+
+		return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
 	})
 
 	ref, err := manifest.ParseReference("library/app")
@@ -196,6 +198,170 @@ func TestScanRepositoryReturnsUnderlyingTargetErrorWhenAllTargetsFail(t *testing
 	}
 	if !strings.Contains(err.Error(), "status=404") {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestScanRepositoryReturnsPartialResultWhenTargetLimitExceeded(t *testing.T) {
+	digestOne := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	digestTwo := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	transport := repoRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return repoResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return repoResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		switch request.URL.Path {
+		case "/v2/library/app/tags/list":
+			return repoResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["latest","1.0"]}`), nil), nil
+		case "/v2/library/app/manifests/latest":
+			if request.Method == http.MethodHead {
+				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+					"Docker-Content-Digest": digestOne,
+				}), nil
+			}
+		case "/v2/library/app/manifests/1.0":
+			if request.Method == http.MethodHead {
+				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+					"Docker-Content-Digest": digestTwo,
+				}), nil
+			}
+		default:
+			return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+		}
+
+		return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+	})
+
+	ref, err := manifest.ParseReference("library/app")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	result, err := Scan(context.Background(), Request{
+		Reference: ref,
+		Registry: registry.NewClient(registry.Options{
+			BaseURL: "https://registry.test",
+			HTTPClient: &http.Client{
+				Transport: transport,
+			},
+		}),
+		Detectors:            detectors.Default(),
+		MaxFileBytes:         1 << 20,
+		TagPageSize:          100,
+		MaxRepositoryTargets: 1,
+	})
+	if err == nil {
+		t.Fatal("Scan() error = nil")
+	}
+	if !strings.Contains(err.Error(), "max repository targets limit") {
+		t.Fatalf("err = %v", err)
+	}
+	if result.TagsResolved != 2 {
+		t.Fatalf("result.TagsResolved = %d", result.TagsResolved)
+	}
+	if result.TargetCount != 2 {
+		t.Fatalf("result.TargetCount = %d", result.TargetCount)
+	}
+	if result.CompletedTargetCount != 0 {
+		t.Fatalf("result.CompletedTargetCount = %d", result.CompletedTargetCount)
+	}
+}
+
+func TestScanRepositoryAbortsOnLimitErrorAndPreservesCompletedTargets(t *testing.T) {
+	digestOne := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	digestTwo := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	configOne := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	configTwo := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	transport := repoRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return repoResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return repoResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		switch request.URL.Path {
+		case "/v2/library/app/tags/list":
+			return repoResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["1.0","latest"]}`), nil), nil
+		case "/v2/library/app/manifests/1.0":
+			if request.Method == http.MethodHead {
+				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+					"Docker-Content-Digest": digestOne,
+				}), nil
+			}
+		case "/v2/library/app/manifests/latest":
+			if request.Method == http.MethodHead {
+				return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, nil, map[string]string{
+					"Docker-Content-Digest": digestTwo,
+				}), nil
+			}
+		case "/v2/library/app/manifests/" + digestOne:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+configOne+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": digestOne,
+			}), nil
+		case "/v2/library/app/manifests/" + digestTwo:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+configTwo+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": digestTwo,
+			}), nil
+		case "/v2/library/app/blobs/" + configOne:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"amd64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"]}}`), nil), nil
+		case "/v2/library/app/blobs/" + configTwo:
+			return repoResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"amd64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"],"User":"builder","WorkingDir":"https://builder:supersecretvalue@registry.internal/app"}}`), nil), nil
+		default:
+			return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+		}
+
+		return repoResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+	})
+
+	ref, err := manifest.ParseReference("library/app")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	result, err := Scan(context.Background(), Request{
+		Reference: ref,
+		Registry: registry.NewClient(registry.Options{
+			BaseURL: "https://registry.test",
+			HTTPClient: &http.Client{
+				Transport: transport,
+			},
+		}),
+		Detectors:      detectors.Default(),
+		MaxFileBytes:   1 << 20,
+		MaxConfigBytes: 128,
+		TagPageSize:    100,
+	})
+	if err == nil {
+		t.Fatal("Scan() error = nil")
+	}
+	if !strings.Contains(err.Error(), "max config bytes limit") {
+		t.Fatalf("err = %v", err)
+	}
+	if result.CompletedTargetCount != 1 {
+		t.Fatalf("result.CompletedTargetCount = %d", result.CompletedTargetCount)
+	}
+	if result.FailedTargetCount != 1 {
+		t.Fatalf("result.FailedTargetCount = %d", result.FailedTargetCount)
+	}
+	if result.TotalFindings == 0 {
+		t.Fatal("result.TotalFindings = 0")
+	}
+	if len(result.Targets) != 2 {
+		t.Fatalf("len(result.Targets) = %d", len(result.Targets))
+	}
+	if result.Targets[1].Error == "" {
+		t.Fatal("expected failed target error")
 	}
 }
 

--- a/internal/limits/limits.go
+++ b/internal/limits/limits.go
@@ -1,0 +1,64 @@
+package limits
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type Kind string
+
+const (
+	KindManifestBytes     Kind = "manifest_bytes"
+	KindConfigBytes       Kind = "config_bytes"
+	KindRepositoryTags    Kind = "repository_tags"
+	KindRepositoryTargets Kind = "repository_targets"
+)
+
+type ExceededError struct {
+	Kind    Kind
+	Limit   int64
+	Subject string
+}
+
+func (e *ExceededError) Error() string {
+	subject := strings.TrimSpace(e.Subject)
+	if subject == "" {
+		subject = "resource"
+	}
+
+	switch e.Kind {
+	case KindManifestBytes:
+		return fmt.Sprintf("%s exceeded max manifest bytes limit of %d", subject, e.Limit)
+	case KindConfigBytes:
+		return fmt.Sprintf("%s exceeded max config bytes limit of %d", subject, e.Limit)
+	case KindRepositoryTags:
+		return fmt.Sprintf("%s exceeded max repository tags limit of %d", subject, e.Limit)
+	case KindRepositoryTargets:
+		return fmt.Sprintf("%s exceeded max repository targets limit of %d", subject, e.Limit)
+	default:
+		return fmt.Sprintf("%s exceeded configured limit of %d", subject, e.Limit)
+	}
+}
+
+func NewExceeded(kind Kind, limit int64, subject string) error {
+	return &ExceededError{
+		Kind:    kind,
+		Limit:   limit,
+		Subject: subject,
+	}
+}
+
+func IsExceeded(err error) bool {
+	var target *ExceededError
+	return errors.As(err, &target)
+}
+
+func AsExceeded(err error) (*ExceededError, bool) {
+	var target *ExceededError
+	if !errors.As(err, &target) {
+		return nil, false
+	}
+
+	return target, true
+}

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -14,21 +14,26 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/brumbelow/layerleak/internal/limits"
 	"github.com/brumbelow/layerleak/internal/manifest"
 )
 
 type Options struct {
-	BaseURL    string
-	AuthURL    string
-	HTTPClient *http.Client
+	BaseURL          string
+	AuthURL          string
+	HTTPClient       *http.Client
+	RequestAttempts  int
+	MaxManifestBytes int64
 }
 
 type Client struct {
-	baseURL      *url.URL
-	authURL      *url.URL
-	httpClient   *http.Client
-	tokenCache   map[string]string
-	tokenCacheMu sync.Mutex
+	baseURL          *url.URL
+	authURL          *url.URL
+	httpClient       *http.Client
+	requestAttempts  int
+	maxManifestBytes int64
+	tokenCache       map[string]string
+	tokenCacheMu     sync.Mutex
 }
 
 type ManifestResponse struct {
@@ -55,8 +60,6 @@ type bearerChallenge struct {
 	Scope   string
 }
 
-const requestAttempts = 2
-
 func NewClient(options Options) *Client {
 	baseURL, _ := url.Parse(defaultString(options.BaseURL, "https://registry-1.docker.io"))
 	authURL, _ := url.Parse(defaultString(options.AuthURL, "https://auth.docker.io/token"))
@@ -64,12 +67,18 @@ func NewClient(options Options) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
+	requestAttempts := options.RequestAttempts
+	if requestAttempts <= 0 {
+		requestAttempts = 2
+	}
 
 	return &Client{
-		baseURL:    baseURL,
-		authURL:    authURL,
-		httpClient: httpClient,
-		tokenCache: make(map[string]string),
+		baseURL:          baseURL,
+		authURL:          authURL,
+		httpClient:       httpClient,
+		requestAttempts:  requestAttempts,
+		maxManifestBytes: options.MaxManifestBytes,
+		tokenCache:       make(map[string]string),
 	}
 }
 
@@ -113,9 +122,9 @@ func (c *Client) FetchManifest(ctx context.Context, repository, identifier strin
 	}
 	defer response.Body.Close()
 
-	body, err := io.ReadAll(response.Body)
+	body, err := readManifestBody(response.Body, c.maxManifestBytes, identifier)
 	if err != nil {
-		return ManifestResponse{}, fmt.Errorf("read manifest response: %w", err)
+		return ManifestResponse{}, err
 	}
 
 	return ManifestResponse{
@@ -168,7 +177,7 @@ func (c *Client) OpenBlob(ctx context.Context, repository, digest string) (BlobR
 	}, nil
 }
 
-func (c *Client) ListTags(ctx context.Context, repository string, pageSize int) ([]string, error) {
+func (c *Client) ListTags(ctx context.Context, repository string, pageSize, maxTags int) ([]string, error) {
 	if pageSize <= 0 {
 		pageSize = 100
 	}
@@ -206,6 +215,10 @@ func (c *Client) ListTags(ctx context.Context, repository string, pageSize int) 
 			}
 			if _, ok := seen[tag]; ok {
 				continue
+			}
+			if maxTags > 0 && len(tags) >= maxTags {
+				sort.Strings(tags)
+				return tags, limits.NewExceeded(limits.KindRepositoryTags, int64(maxTags), "repository "+repository)
 			}
 			seen[tag] = struct{}{}
 			tags = append(tags, tag)
@@ -289,7 +302,7 @@ func (c *Client) checkResponse(response *http.Response) (*http.Response, error) 
 
 func (c *Client) executeRequest(ctx context.Context, method, targetURL, accept, token string) (*http.Response, error) {
 	var lastErr error
-	for attempt := 0; attempt < requestAttempts; attempt++ {
+	for attempt := 0; attempt < c.requestAttempts; attempt++ {
 		request, err := http.NewRequestWithContext(ctx, method, targetURL, nil)
 		if err != nil {
 			return nil, fmt.Errorf("create registry request: %w", err)
@@ -304,12 +317,12 @@ func (c *Client) executeRequest(ctx context.Context, method, targetURL, accept, 
 		response, err := c.httpClient.Do(request)
 		if err != nil {
 			lastErr = err
-			if attempt+1 < requestAttempts && isRetryableRequestError(ctx, err) {
+			if attempt+1 < c.requestAttempts && isRetryableRequestError(ctx, err) {
 				continue
 			}
 			return nil, err
 		}
-		if attempt+1 < requestAttempts && isRetryableStatus(response.StatusCode) {
+		if attempt+1 < c.requestAttempts && isRetryableStatus(response.StatusCode) {
 			response.Body.Close()
 			lastErr = fmt.Errorf("transient registry status %d", response.StatusCode)
 			continue
@@ -507,6 +520,27 @@ func appendURLQuery(targetURL string, values map[string]string) (string, error) 
 	}
 	parsed.RawQuery = query.Encode()
 	return parsed.String(), nil
+}
+
+func readManifestBody(reader io.Reader, maxBytes int64, identifier string) ([]byte, error) {
+	if maxBytes <= 0 {
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("read manifest response: %w", err)
+		}
+		return body, nil
+	}
+
+	limited := io.LimitReader(reader, maxBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest response: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, limits.NewExceeded(limits.KindManifestBytes, maxBytes, "manifest "+strings.TrimSpace(identifier))
+	}
+
+	return body, nil
 }
 
 func nextLinkURL(currentURL, header string) (string, bool, error) {

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -162,7 +162,7 @@ func TestListTagsFollowsPagination(t *testing.T) {
 		},
 	})
 
-	tags, err := client.ListTags(context.Background(), "library/app", 2)
+	tags, err := client.ListTags(context.Background(), "library/app", 2, 0)
 	if err != nil {
 		t.Fatalf("ListTags() error = %v", err)
 	}
@@ -170,6 +170,39 @@ func TestListTagsFollowsPagination(t *testing.T) {
 		t.Fatalf("len(tags) = %d", len(tags))
 	}
 	if strings.Join(tags, ",") != "1.0,2.0,3.0" {
+		t.Fatalf("tags = %q", strings.Join(tags, ","))
+	}
+}
+
+func TestListTagsReturnsPartialTagsWhenLimitExceeded(t *testing.T) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return jsonResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return jsonResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+		return jsonResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["latest","2.0","1.0"]}`), nil), nil
+	})
+
+	client := NewClient(Options{
+		BaseURL: "https://registry.test",
+		HTTPClient: &http.Client{
+			Transport: transport,
+		},
+	})
+
+	tags, err := client.ListTags(context.Background(), "library/app", 100, 2)
+	if err == nil {
+		t.Fatal("ListTags() error = nil")
+	}
+	if !strings.Contains(err.Error(), "max repository tags limit") {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.Join(tags, ",") != "2.0,latest" {
 		t.Fatalf("tags = %q", strings.Join(tags, ","))
 	}
 }
@@ -270,6 +303,62 @@ func TestResolveManifestRetriesRequestTimeout(t *testing.T) {
 	}
 	if resolved.Digest != "sha256:resolved" {
 		t.Fatalf("resolved.Digest = %q", resolved.Digest)
+	}
+}
+
+func TestFetchManifestHonorsConfiguredRequestAttempts(t *testing.T) {
+	requests := 0
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		return nil, context.DeadlineExceeded
+	})
+
+	client := NewClient(Options{
+		BaseURL:         "https://registry.test",
+		RequestAttempts: 1,
+		HTTPClient: &http.Client{
+			Transport: transport,
+		},
+	})
+
+	if _, err := client.FetchManifest(context.Background(), "library/app", "latest"); err == nil {
+		t.Fatal("FetchManifest() error = nil")
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d", requests)
+	}
+}
+
+func TestFetchManifestFailsWhenManifestBodyExceedsLimit(t *testing.T) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return jsonResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return jsonResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		return jsonResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2}`), map[string]string{
+			"Docker-Content-Digest": "sha256:manifest",
+		}), nil
+	})
+
+	client := NewClient(Options{
+		BaseURL:          "https://registry.test",
+		MaxManifestBytes: 8,
+		HTTPClient: &http.Client{
+			Transport: transport,
+		},
+	})
+
+	if _, err := client.FetchManifest(context.Background(), "library/app", "latest"); err == nil {
+		t.Fatal("FetchManifest() error = nil")
+	} else if !strings.Contains(err.Error(), "max manifest bytes limit") {
+		t.Fatalf("err = %v", err)
 	}
 }
 

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -11,18 +11,20 @@ import (
 	"github.com/brumbelow/layerleak/internal/detectors"
 	"github.com/brumbelow/layerleak/internal/findings"
 	"github.com/brumbelow/layerleak/internal/layers"
+	"github.com/brumbelow/layerleak/internal/limits"
 	"github.com/brumbelow/layerleak/internal/manifest"
 	"github.com/brumbelow/layerleak/internal/registry"
 )
 
 type Request struct {
-	Reference    manifest.Reference
-	Platform     string
-	Registry     *registry.Client
-	Detectors    detectors.Set
-	Logger       *slog.Logger
-	MaxFileBytes int64
-	Progress     ProgressFunc
+	Reference      manifest.Reference
+	Platform       string
+	Registry       *registry.Client
+	Detectors      detectors.Set
+	Logger         *slog.Logger
+	MaxFileBytes   int64
+	MaxConfigBytes int64
+	Progress       ProgressFunc
 }
 
 type ProgressPhase string
@@ -78,8 +80,11 @@ type PlatformResult struct {
 }
 
 func Scan(ctx context.Context, request Request) (Result, error) {
+	result := Result{
+		RequestedReference: request.Reference.Original,
+	}
 	if request.Registry == nil {
-		return Result{}, fmt.Errorf("registry client is required")
+		return result, fmt.Errorf("registry client is required")
 	}
 	if request.MaxFileBytes <= 0 {
 		request.MaxFileBytes = 1 << 20
@@ -94,24 +99,20 @@ func Scan(ctx context.Context, request Request) (Result, error) {
 
 	rootResponse, err := request.Registry.FetchManifest(ctx, request.Reference.Repository, request.Reference.Identifier())
 	if err != nil {
-		return Result{}, err
+		return result, err
 	}
 
 	document, err := manifest.ParseDocument(rootResponse.MediaType, rootResponse.Body)
 	if err != nil {
-		return Result{}, err
+		return result, err
 	}
 
 	requestedDigest := firstNonEmpty(rootResponse.Digest, request.Reference.Digest)
 	if requestedDigest == "" {
-		return Result{}, fmt.Errorf("registry did not return a resolved digest for %s", request.Reference.Original)
+		return result, fmt.Errorf("registry did not return a resolved digest for %s", request.Reference.Original)
 	}
-
-	result := Result{
-		RequestedReference: request.Reference.Original,
-		ResolvedReference:  request.Reference.CanonicalString(requestedDigest),
-		RequestedDigest:    requestedDigest,
-	}
+	result.ResolvedReference = request.Reference.CanonicalString(requestedDigest)
+	result.RequestedDigest = requestedDigest
 
 	type target struct {
 		descriptor manifest.Descriptor
@@ -131,13 +132,13 @@ func Scan(ctx context.Context, request Request) (Result, error) {
 	case manifest.DocumentKindIndex:
 		selected, err := manifest.SelectDescriptors(document.Index, request.Platform)
 		if err != nil {
-			return Result{}, err
+			return result, err
 		}
 		for _, descriptor := range selected {
 			targets = append(targets, target{descriptor: descriptor})
 		}
 	default:
-		return Result{}, fmt.Errorf("unsupported manifest document kind: %s", document.Kind)
+		return result, fmt.Errorf("unsupported manifest document kind: %s", document.Kind)
 	}
 
 	result.ManifestCount = len(targets)
@@ -186,6 +187,10 @@ func Scan(ctx context.Context, request Request) (Result, error) {
 				CurrentManifestDigest: target.descriptor.Digest,
 				Message:               err.Error(),
 			})
+			if limits.IsExceeded(err) {
+				finalizeResult(&result, allDetailedFindings, allSuppressedDetailedFindings)
+				return result, err
+			}
 			continue
 		}
 
@@ -208,25 +213,10 @@ func Scan(ctx context.Context, request Request) (Result, error) {
 		})
 	}
 
+	finalizeResult(&result, allDetailedFindings, allSuppressedDetailedFindings)
 	if result.CompletedManifestCount == 0 {
 		return result, allSelectedManifestsFailedError(result.PlatformResults)
 	}
-
-	result.DetailedFindings = findings.DeduplicateDetailed(allDetailedFindings)
-	result.Findings = make([]findings.Finding, 0, len(result.DetailedFindings))
-	for _, item := range result.DetailedFindings {
-		result.Findings = append(result.Findings, item.PublicFinding())
-	}
-	result.SuppressedDetailedFindings = findings.DeduplicateDetailed(allSuppressedDetailedFindings)
-	result.SuppressedFindings = make([]findings.Finding, 0, len(result.SuppressedDetailedFindings))
-	for _, item := range result.SuppressedDetailedFindings {
-		result.SuppressedFindings = append(result.SuppressedFindings, item.PublicFinding())
-	}
-	result.TotalFindings = len(result.Findings)
-	result.UniqueFingerprints = findings.UniqueFingerprintCount(result.Findings)
-	result.SuppressedFindingsCount = len(result.SuppressedFindings)
-	result.SuppressedUniqueFingerprints = findings.UniqueFingerprintCount(result.SuppressedFindings)
-	sortPlatformResults(result.PlatformResults)
 	emitProgress(request, ProgressUpdate{
 		Phase:                 ProgressPhaseCompleted,
 		Repository:            request.Reference.Repository,
@@ -256,10 +246,10 @@ func scanManifest(ctx context.Context, request Request, descriptor manifest.Desc
 	if err != nil {
 		return PlatformResult{}, nil, nil, fmt.Errorf("fetch config blob: %w", err)
 	}
-	configBody, err := io.ReadAll(configBlob.Body)
+	configBody, err := readConfigBody(configBlob.Body, request.MaxConfigBytes, imageManifest.Config.Digest)
 	configBlob.Body.Close()
 	if err != nil {
-		return PlatformResult{}, nil, nil, fmt.Errorf("read config blob: %w", err)
+		return PlatformResult{}, nil, nil, err
 	}
 
 	imageConfig, err := manifest.ParseImageConfig(configBody)
@@ -527,6 +517,45 @@ func emitProgress(request Request, update ProgressUpdate) {
 		update.Repository = request.Reference.Repository
 	}
 	request.Progress(update)
+}
+
+func finalizeResult(result *Result, actionable, suppressed []findings.DetailedFinding) {
+	result.DetailedFindings = findings.DeduplicateDetailed(actionable)
+	result.Findings = make([]findings.Finding, 0, len(result.DetailedFindings))
+	for _, item := range result.DetailedFindings {
+		result.Findings = append(result.Findings, item.PublicFinding())
+	}
+	result.SuppressedDetailedFindings = findings.DeduplicateDetailed(suppressed)
+	result.SuppressedFindings = make([]findings.Finding, 0, len(result.SuppressedDetailedFindings))
+	for _, item := range result.SuppressedDetailedFindings {
+		result.SuppressedFindings = append(result.SuppressedFindings, item.PublicFinding())
+	}
+	result.TotalFindings = len(result.Findings)
+	result.UniqueFingerprints = findings.UniqueFingerprintCount(result.Findings)
+	result.SuppressedFindingsCount = len(result.SuppressedFindings)
+	result.SuppressedUniqueFingerprints = findings.UniqueFingerprintCount(result.SuppressedFindings)
+	sortPlatformResults(result.PlatformResults)
+}
+
+func readConfigBody(reader io.Reader, maxBytes int64, digest string) ([]byte, error) {
+	if maxBytes <= 0 {
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("read config blob: %w", err)
+		}
+		return body, nil
+	}
+
+	limited := io.LimitReader(reader, maxBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read config blob: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, limits.NewExceeded(limits.KindConfigBytes, maxBytes, "config blob "+strings.TrimSpace(digest))
+	}
+
+	return body, nil
 }
 
 func manifestStatusMessage(prefix string, descriptor manifest.Descriptor) string {

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -335,6 +335,150 @@ func TestScanReturnsUnderlyingManifestFailureWhenAllSelectedManifestsFail(t *tes
 	}
 }
 
+func TestScanReturnsPartialResultWhenConfigLimitExceededAfterCompletedManifest(t *testing.T) {
+	firstManifestDigest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	secondManifestDigest := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	firstConfigDigest := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	secondConfigDigest := "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	indexDigest := "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return testResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return testResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		switch request.URL.Path {
+		case "/v2/library/app/manifests/latest":
+			return testResponse(http.StatusOK, manifest.MediaTypeOCIImageIndex, []byte(`{
+  "schemaVersion":2,
+  "mediaType":"`+manifest.MediaTypeOCIImageIndex+`",
+  "manifests":[
+    {"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","digest":"`+firstManifestDigest+`","size":1,"platform":{"os":"linux","architecture":"amd64"}},
+    {"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","digest":"`+secondManifestDigest+`","size":1,"platform":{"os":"linux","architecture":"arm64"}}
+  ]
+}`), map[string]string{
+				"Docker-Content-Digest": indexDigest,
+			}), nil
+		case "/v2/library/app/manifests/" + firstManifestDigest:
+			return testResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+firstConfigDigest+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": firstManifestDigest,
+			}), nil
+		case "/v2/library/app/manifests/" + secondManifestDigest:
+			return testResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+secondConfigDigest+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": secondManifestDigest,
+			}), nil
+		case "/v2/library/app/blobs/" + firstConfigDigest:
+			return testResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"amd64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"]}}`), nil), nil
+		case "/v2/library/app/blobs/" + secondConfigDigest:
+			return testResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"arm64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"],"User":"builder","WorkingDir":"https://builder:supersecretvalue@registry.internal/app"}}`), nil), nil
+		default:
+			return testResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+		}
+	})
+
+	ref, err := manifest.ParseReference("library/app:latest")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	result, err := Scan(context.Background(), Request{
+		Reference: ref,
+		Registry: registry.NewClient(registry.Options{
+			BaseURL: "https://registry.test",
+			HTTPClient: &http.Client{
+				Transport: transport,
+			},
+		}),
+		Detectors:      detectors.Default(),
+		MaxFileBytes:   1 << 20,
+		MaxConfigBytes: 128,
+	})
+	if err == nil {
+		t.Fatal("Scan() error = nil")
+	}
+	if !strings.Contains(err.Error(), "max config bytes limit") {
+		t.Fatalf("err = %v", err)
+	}
+	if result.CompletedManifestCount != 1 {
+		t.Fatalf("result.CompletedManifestCount = %d", result.CompletedManifestCount)
+	}
+	if result.FailedManifestCount != 1 {
+		t.Fatalf("result.FailedManifestCount = %d", result.FailedManifestCount)
+	}
+	if result.TotalFindings == 0 {
+		t.Fatal("result.TotalFindings = 0")
+	}
+}
+
+func TestScanReturnsEmptyPartialResultWhenConfigLimitExceededBeforeAnyManifestCompletes(t *testing.T) {
+	manifestDigest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	configDigest := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return testResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return testResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		switch request.URL.Path {
+		case "/v2/library/app/manifests/latest":
+			return testResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+configDigest+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": manifestDigest,
+			}), nil
+		case "/v2/library/app/blobs/" + configDigest:
+			return testResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"amd64","os":"linux","config":{"Env":["GH_TOKEN=ghp_123456789012345678901234567890123456"],"User":"builder","WorkingDir":"https://builder:supersecretvalue@registry.internal/app"}}`), nil), nil
+		default:
+			return testResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+		}
+	})
+
+	ref, err := manifest.ParseReference("library/app:latest")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	result, err := Scan(context.Background(), Request{
+		Reference: ref,
+		Registry: registry.NewClient(registry.Options{
+			BaseURL: "https://registry.test",
+			HTTPClient: &http.Client{
+				Transport: transport,
+			},
+		}),
+		Detectors:      detectors.Default(),
+		MaxFileBytes:   1 << 20,
+		MaxConfigBytes: 128,
+	})
+	if err == nil {
+		t.Fatal("Scan() error = nil")
+	}
+	if !strings.Contains(err.Error(), "max config bytes limit") {
+		t.Fatalf("err = %v", err)
+	}
+	if result.CompletedManifestCount != 0 {
+		t.Fatalf("result.CompletedManifestCount = %d", result.CompletedManifestCount)
+	}
+	if result.TotalFindings != 0 {
+		t.Fatalf("result.TotalFindings = %d", result.TotalFindings)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("len(result.Findings) = %d", len(result.Findings))
+	}
+}
+
 type tarEntry struct {
 	name string
 	body string


### PR DESCRIPTION
- Add a shared limit-error layer in internal/limits/limits.go.
- Wire configurable manifest/config/repository limits through config, registry, scanner, jobs, and CLI paths.
- Make configured limit breaches fail closed, stop further work, and preserve real partial results instead of truncating or continuing.
- Update cli scan so limit-caused incomplete scans still write the findings file, persist to Postgres when configured, render summary/JSON output, and exit with code 1.
- Document the new environment variables and partial-result behavior in README.md.
- Add test coverage across config, registry client, scanner, jobs, and CLI.