### PR TITLE
Workflow/Actions improvements

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,6 @@
+---
+exclude_paths:
+  - ".github/**"
+  - "migrations/**"
+  - "*.md"
+  - "**/*.md"

--- a/revive.toml
+++ b/revive.toml
@@ -1,0 +1,4 @@
+enableDefaultRules = true
+
+[rule.exported]
+Disabled = true


### PR DESCRIPTION
• Added repo-owned Codacy config in .codacy.yml:1 to exclude the three noisy path classes generating the current backlog: .github/**, migrations/**, and Markdown files. I also added revive.toml:1 to keep Revive’s default rules but disable only rule.exported, which is the source of the 172 Revive_exported alerts.