### PR TITLE
Hardening and default display

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ Result and database configuration:
 ```bash
 export LAYERLEAK_FINDINGS_DIR=findings
 export LAYERLEAK_API_ADDR=127.0.0.1:8080
+export LAYERLEAK_PERSIST_RAW_SECRETS=0
 export LAYERLEAK_TAG_PAGE_SIZE=100
 export LAYERLEAK_MAX_LAYER_BYTES=536870912
 export LAYERLEAK_MAX_LAYER_ENTRIES=50000
 export LAYERLEAK_MAX_MANIFEST_BYTES=0
 export LAYERLEAK_MAX_CONFIG_BYTES=0
+export LAYERLEAK_MAX_TAG_RESPONSE_BYTES=8388608
 export LAYERLEAK_MAX_REPOSITORY_TAGS=0
 export LAYERLEAK_MAX_REPOSITORY_TARGETS=0
 export LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS=2
@@ -73,10 +75,12 @@ export LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerl
 ```
 
 If `LAYERLEAK_FINDINGS_DIR` is not set, layerleak writes JSON findings files to `findings/` under the repo root.
-Saved findings files contain only detections, including unredacted finding values and unredacted context snippets.
+Saved findings files contain only detections and are redacted by default.
+Set `LAYERLEAK_PERSIST_RAW_SECRETS=1` only if you explicitly want raw finding values and raw context snippets written to disk and Postgres.
 `LAYERLEAK_TAG_PAGE_SIZE` controls Docker Hub tag-list pagination for repository-wide scans.
 `LAYERLEAK_MAX_LAYER_BYTES` defaults to `536870912` (512 MiB) of decompressed layer stream data per layer, and `LAYERLEAK_MAX_LAYER_ENTRIES` defaults to `50000` tar entries per layer.
-`LAYERLEAK_MAX_LAYER_BYTES`, `LAYERLEAK_MAX_LAYER_ENTRIES`, `LAYERLEAK_MAX_MANIFEST_BYTES`, `LAYERLEAK_MAX_CONFIG_BYTES`, `LAYERLEAK_MAX_REPOSITORY_TAGS`, and `LAYERLEAK_MAX_REPOSITORY_TARGETS` are disabled when set to `0`.
+`LAYERLEAK_MAX_TAG_RESPONSE_BYTES` defaults to `8388608` (8 MiB) per Docker Hub tag-list response page.
+`LAYERLEAK_MAX_LAYER_BYTES`, `LAYERLEAK_MAX_LAYER_ENTRIES`, `LAYERLEAK_MAX_MANIFEST_BYTES`, `LAYERLEAK_MAX_CONFIG_BYTES`, `LAYERLEAK_MAX_TAG_RESPONSE_BYTES`, `LAYERLEAK_MAX_REPOSITORY_TAGS`, and `LAYERLEAK_MAX_REPOSITORY_TARGETS` are disabled when set to `0`.
 If enabled, those limits fail the scan with a clear error instead of silently truncating work.
 `LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS` controls registry request retries and defaults to `2`.
 `LAYERLEAK_API_ADDR` controls the bind address for the API server and defaults to `127.0.0.1:8080`.
@@ -120,7 +124,8 @@ Operational defaults:
 
 Secret-safety note:
 
-- Postgres persistence stores raw finding values and raw snippets, not only redacted previews.
+- Postgres persistence stores redacted previews by default.
+- If `LAYERLEAK_PERSIST_RAW_SECRETS=1`, Postgres also stores raw finding values and raw snippets.
 - The `scan_runs.result_json` snapshot stays redacted.
 - Use a dedicated database or schema for layerleak.
 - For the safest purge path, drop the dedicated database or schema instead of trying to surgically delete individual rows.
@@ -150,8 +155,9 @@ Run a scan against a public Docker Hub image:
 Every scan writes a JSON findings file to the findings output directory.
 If `LAYERLEAK_FINDINGS_DIR` is not set, the default output directory is `findings/` under the repo root.
 
-Those saved findings files contain only finding records, including the exact match value, exact source location, unredacted snippet, disposition metadata, and line number for each finding.
-If Postgres persistence is enabled, the same raw finding material is stored in the `findings` and `finding_occurrences` tables.
+Those saved findings files contain finding records with `redacted_value`, redacted `context_snippet`, exact source location, disposition metadata, and line number for each finding.
+If `LAYERLEAK_PERSIST_RAW_SECRETS=1`, the saved findings files also include raw `value` and `raw_context_snippet`.
+If Postgres persistence is enabled, raw `findings.value` and `finding_occurrences.raw_snippet` stay empty unless `LAYERLEAK_PERSIST_RAW_SECRETS=1`.
 For multi-arch images, layerleak skips attestation and provenance manifests such as `application/vnd.in-toto+json` instead of counting them as failed platform scans.
 If you pass a bare repository name such as `mongo`, layerleak enumerates all public tags in that repository, resolves each tag to a digest, groups duplicate digests, and scans the distinct targets. If you want a single image only, pass an explicit tag or digest such as `mongo:latest` or `mongo@sha256:...`.
 

--- a/internal/api/run.go
+++ b/internal/api/run.go
@@ -22,7 +22,8 @@ func Run() error {
 	}
 
 	store, err := storage.NewPostgresStore(storage.PostgresConfig{
-		DatabaseURL: cfg.DatabaseURL,
+		DatabaseURL:       cfg.DatabaseURL,
+		PersistRawSecrets: cfg.PersistRawSecrets,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/results.go
+++ b/internal/cli/results.go
@@ -26,9 +26,11 @@ type persistedFinding struct {
 	LayerDigest         string                     `json:"layer_digest,omitempty"`
 	Key                 string                     `json:"key,omitempty"`
 	LineNumber          int                        `json:"line_number,omitempty"`
-	Value               string                     `json:"value"`
+	RedactedValue       string                     `json:"redacted_value"`
+	Value               string                     `json:"value,omitempty"`
 	Fingerprint         string                     `json:"fingerprint"`
 	ContextSnippet      string                     `json:"context_snippet"`
+	RawContextSnippet   string                     `json:"raw_context_snippet,omitempty"`
 	SourceLocation      string                     `json:"source_location"`
 	MatchStart          int                        `json:"match_start"`
 	MatchEnd            int                        `json:"match_end"`
@@ -39,17 +41,17 @@ type persistedFinding struct {
 
 const persistedLowConfidenceGroupCap = 3
 
-func writeResultFile(configuredDir string, result jobs.Result) (string, error) {
+func writeResultFile(configuredDir string, persistRawSecrets bool, result jobs.Result) (string, error) {
 	findingsDir, err := resolveFindingsDir(configuredDir)
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(findingsDir, 0o755); err != nil {
+	if err := os.MkdirAll(findingsDir, 0o700); err != nil {
 		return "", fmt.Errorf("create findings directory: %w", err)
 	}
 
 	filePath := filepath.Join(findingsDir, buildResultFileName(result))
-	file, err := os.Create(filePath)
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return "", fmt.Errorf("create findings result file: %w", err)
 	}
@@ -57,20 +59,20 @@ func writeResultFile(configuredDir string, result jobs.Result) (string, error) {
 
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(buildPersistedFindings(result)); err != nil {
+	if err := encoder.Encode(buildPersistedFindings(result, persistRawSecrets)); err != nil {
 		return "", fmt.Errorf("write findings result file: %w", err)
 	}
 
 	return filePath, nil
 }
 
-func buildPersistedFindings(result jobs.Result) []persistedFinding {
+func buildPersistedFindings(result jobs.Result, persistRawSecrets bool) []persistedFinding {
 	allDetailedFindings := append([]findings.DetailedFinding{}, result.DetailedFindings...)
 	allDetailedFindings = append(allDetailedFindings, result.SuppressedDetailedFindings...)
 
 	items := make([]persistedFinding, 0, len(allDetailedFindings))
 	for _, item := range allDetailedFindings {
-		items = append(items, persistedFinding{
+		persisted := persistedFinding{
 			DetectorName:        item.DetectorName,
 			Confidence:          item.Confidence,
 			Disposition:         item.Disposition,
@@ -82,14 +84,19 @@ func buildPersistedFindings(result jobs.Result) []persistedFinding {
 			LayerDigest:         item.LayerDigest,
 			Key:                 item.Key,
 			LineNumber:          item.LineNumber,
-			Value:               item.Value,
+			RedactedValue:       item.RedactedValue,
 			Fingerprint:         item.Fingerprint,
-			ContextSnippet:      item.RawSnippet,
+			ContextSnippet:      item.ContextSnippet,
 			SourceLocation:      item.SourceLocation,
 			MatchStart:          item.MatchStart,
 			MatchEnd:            item.MatchEnd,
 			PresentInFinalImage: item.PresentInFinalImage,
-		})
+		}
+		if persistRawSecrets {
+			persisted.Value = item.Value
+			persisted.RawContextSnippet = item.RawSnippet
+		}
+		items = append(items, persisted)
 	}
 
 	return capPersistedLowConfidenceFindings(items)
@@ -141,7 +148,6 @@ func persistedFindingGroupKey(item persistedFinding) (string, bool) {
 		item.LayerDigest,
 		item.Key,
 		strconv.Itoa(item.LineNumber),
-		item.Value,
 		item.Fingerprint,
 		boolString(item.PresentInFinalImage),
 	}, "|"), true

--- a/internal/cli/results_test.go
+++ b/internal/cli/results_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestWriteResultFileUsesConfiguredDirectory(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir := filepath.Join(t.TempDir(), "nested", "findings")
 
-	filePath, err := writeResultFile(tempDir, jobs.Result{
+	filePath, err := writeResultFile(tempDir, false, jobs.Result{
 		RequestedDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		TotalFindings:   3,
 		DetailedFindings: []findings.DetailedFinding{
@@ -27,7 +27,9 @@ func TestWriteResultFileUsesConfiguredDirectory(t *testing.T) {
 					ManifestDigest:      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					Platform:            manifest.Platform{OS: "linux", Architecture: "amd64"},
 					Key:                 "TOKEN",
+					RedactedValue:       "ghp********************************56",
 					Fingerprint:         "fingerprint",
+					ContextSnippet:      "TOKEN=ghp********************************56",
 					PresentInFinalImage: true,
 				},
 				Value:          "ghp_123456789012345678901234567890123456",
@@ -59,11 +61,36 @@ func TestWriteResultFileUsesConfiguredDirectory(t *testing.T) {
 	if len(result) != 1 {
 		t.Fatalf("len(result) = %d", len(result))
 	}
-	if result[0].Value != "ghp_123456789012345678901234567890123456" {
+	if result[0].Value != "" {
 		t.Fatalf("result[0].Value = %q", result[0].Value)
+	}
+	if result[0].RawContextSnippet != "" {
+		t.Fatalf("result[0].RawContextSnippet = %q", result[0].RawContextSnippet)
+	}
+	if result[0].RedactedValue != "ghp********************************56" {
+		t.Fatalf("result[0].RedactedValue = %q", result[0].RedactedValue)
+	}
+	if result[0].ContextSnippet != "TOKEN=ghp********************************56" {
+		t.Fatalf("result[0].ContextSnippet = %q", result[0].ContextSnippet)
 	}
 	if result[0].SourceLocation != "env:TOKEN" {
 		t.Fatalf("result[0].SourceLocation = %q", result[0].SourceLocation)
+	}
+
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("Stat(filePath) error = %v", err)
+	}
+	if fileInfo.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("file permissions = %o", fileInfo.Mode().Perm())
+	}
+
+	dirInfo, err := os.Stat(tempDir)
+	if err != nil {
+		t.Fatalf("Stat(tempDir) error = %v", err)
+	}
+	if dirInfo.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("directory permissions = %o", dirInfo.Mode().Perm())
 	}
 }
 
@@ -80,7 +107,7 @@ func TestBuildPersistedFindingsIncludesSuppressedExampleFindings(t *testing.T) {
 				return item
 			}(),
 		},
-	})
+	}, false)
 
 	if len(result) != 2 {
 		t.Fatalf("len(result) = %d", len(result))
@@ -90,6 +117,24 @@ func TestBuildPersistedFindingsIncludesSuppressedExampleFindings(t *testing.T) {
 	}
 	if result[1].DispositionReason != findings.DispositionReasonTestPath {
 		t.Fatalf("result[1].DispositionReason = %q", result[1].DispositionReason)
+	}
+}
+
+func TestBuildPersistedFindingsIncludesRawFieldsWhenEnabled(t *testing.T) {
+	result := buildPersistedFindings(jobs.Result{
+		DetailedFindings: []findings.DetailedFinding{
+			testDetailedFinding("line one", "file:1"),
+		},
+	}, true)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d", len(result))
+	}
+	if result[0].Value != "base-passwd/user-change-gecos" {
+		t.Fatalf("result[0].Value = %q", result[0].Value)
+	}
+	if result[0].RawContextSnippet != "line one" {
+		t.Fatalf("result[0].RawContextSnippet = %q", result[0].RawContextSnippet)
 	}
 }
 
@@ -114,7 +159,7 @@ func TestBuildPersistedFindingsCapsRepeatedLowConfidenceFileFindings(t *testing.
 			testDetailedFinding("line four", "file:4"),
 			testDetailedFinding("line five", "file:5"),
 		},
-	})
+	}, false)
 
 	if len(result) != persistedLowConfidenceGroupCap {
 		t.Fatalf("len(result) = %d", len(result))
@@ -141,7 +186,9 @@ func testDetailedFinding(snippet, location string) findings.DetailedFinding {
 			Platform:            manifest.Platform{OS: "linux", Architecture: "amd64"},
 			FilePath:            "usr/share/doc/base-passwd/README",
 			LayerDigest:         "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			RedactedValue:       "bas***********************os",
 			Fingerprint:         "fingerprint",
+			ContextSnippet:      "base-passwd/user-change-gecos",
 			PresentInFinalImage: true,
 		},
 		Value:          "base-passwd/user-change-gecos",

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -134,7 +134,7 @@ func newScanCmd() *cobra.Command {
 				return err
 			}
 
-			resultPath, err := writeResultFile(cfg.FindingsDir, result)
+			resultPath, err := writeResultFile(cfg.FindingsDir, cfg.PersistRawSecrets, result)
 			if err != nil {
 				_ = progress.Update(progressSnapshot{
 					repository:       ref.Repository,

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -87,8 +87,11 @@ func TestScanCommandJSONOutputAndExitCode(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("ReadFile() error = %v", readErr)
 	}
-	if !strings.Contains(string(body), "ghp_123456789012345678901234567890123456") {
-		t.Fatalf("findings file did not include raw secret: %q", string(body))
+	if strings.Contains(string(body), "ghp_123456789012345678901234567890123456") {
+		t.Fatalf("findings file leaked raw secret: %q", string(body))
+	}
+	if !strings.Contains(string(body), `"redacted_value"`) {
+		t.Fatalf("findings file missing redacted value field: %q", string(body))
 	}
 }
 
@@ -250,8 +253,11 @@ func TestScanCommandWritesPartialResultsOnConfiguredLimitError(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("ReadFile() error = %v", readErr)
 	}
-	if !strings.Contains(string(body), "ghp_123456789012345678901234567890123456") {
-		t.Fatalf("partial findings file missing raw secret: %q", string(body))
+	if strings.Contains(string(body), "ghp_123456789012345678901234567890123456") {
+		t.Fatalf("partial findings file leaked raw secret: %q", string(body))
+	}
+	if !strings.Contains(string(body), `"redacted_value"`) {
+		t.Fatalf("partial findings file missing redacted value field: %q", string(body))
 	}
 }
 

--- a/internal/cli/storage.go
+++ b/internal/cli/storage.go
@@ -17,7 +17,8 @@ func newStore(cfg config.Config) (storage.Store, error) {
 	}
 
 	return storage.NewPostgresStore(storage.PostgresConfig{
-		DatabaseURL: cfg.DatabaseURL,
+		DatabaseURL:       cfg.DatabaseURL,
+		PersistRawSecrets: cfg.PersistRawSecrets,
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,11 +14,13 @@ type Config struct {
 	RegistryBaseURL         string
 	RegistryAuthURL         string
 	HTTPTimeout             time.Duration
+	PersistRawSecrets       bool
 	MaxFileBytes            int64
 	MaxLayerBytes           int64
 	MaxLayerEntries         int
 	MaxManifestBytes        int64
 	MaxConfigBytes          int64
+	MaxTagResponseBytes     int64
 	TagPageSize             int
 	MaxRepositoryTags       int
 	MaxRepositoryTargets    int
@@ -52,6 +54,10 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	maxTagResponseBytes, err := nonNegativeInt64FromEnv("LAYERLEAK_MAX_TAG_RESPONSE_BYTES", 8*(1<<20))
+	if err != nil {
+		return Config{}, err
+	}
 	tagPageSize, err := intFromEnv("LAYERLEAK_TAG_PAGE_SIZE", 100)
 	if err != nil {
 		return Config{}, err
@@ -68,6 +74,10 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	persistRawSecrets, err := boolFromEnv("LAYERLEAK_PERSIST_RAW_SECRETS", false)
+	if err != nil {
+		return Config{}, err
+	}
 
 	return Config{
 		LogLevel:                envOrDefault("LAYERLEAK_LOG_LEVEL", "info"),
@@ -75,11 +85,13 @@ func Load() (Config, error) {
 		RegistryBaseURL:         envOrDefault("LAYERLEAK_REGISTRY_BASE_URL", "https://registry-1.docker.io"),
 		RegistryAuthURL:         envOrDefault("LAYERLEAK_REGISTRY_AUTH_URL", "https://auth.docker.io/token"),
 		HTTPTimeout:             timeout,
+		PersistRawSecrets:       persistRawSecrets,
 		MaxFileBytes:            maxFileBytes,
 		MaxLayerBytes:           maxLayerBytes,
 		MaxLayerEntries:         maxLayerEntries,
 		MaxManifestBytes:        maxManifestBytes,
 		MaxConfigBytes:          maxConfigBytes,
+		MaxTagResponseBytes:     maxTagResponseBytes,
 		TagPageSize:             tagPageSize,
 		MaxRepositoryTags:       maxRepositoryTags,
 		MaxRepositoryTargets:    maxRepositoryTargets,
@@ -107,6 +119,20 @@ func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) 
 	parsed, err := time.ParseDuration(value)
 	if err != nil {
 		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+
+	return parsed, nil
+}
+
+func boolFromEnv(key string, fallback bool) (bool, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("parse %s: %w", key, err)
 	}
 
 	return parsed, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,11 +11,13 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("LAYERLEAK_REGISTRY_BASE_URL", "")
 	t.Setenv("LAYERLEAK_REGISTRY_AUTH_URL", "")
 	t.Setenv("LAYERLEAK_HTTP_TIMEOUT", "")
+	t.Setenv("LAYERLEAK_PERSIST_RAW_SECRETS", "")
 	t.Setenv("LAYERLEAK_MAX_FILE_BYTES", "")
 	t.Setenv("LAYERLEAK_MAX_LAYER_BYTES", "")
 	t.Setenv("LAYERLEAK_MAX_LAYER_ENTRIES", "")
 	t.Setenv("LAYERLEAK_MAX_MANIFEST_BYTES", "")
 	t.Setenv("LAYERLEAK_MAX_CONFIG_BYTES", "")
+	t.Setenv("LAYERLEAK_MAX_TAG_RESPONSE_BYTES", "")
 	t.Setenv("LAYERLEAK_TAG_PAGE_SIZE", "")
 	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TAGS", "")
 	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TARGETS", "")
@@ -46,6 +48,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.HTTPTimeout != 30*time.Second {
 		t.Fatalf("cfg.HTTPTimeout = %s", cfg.HTTPTimeout)
 	}
+	if cfg.PersistRawSecrets {
+		t.Fatal("cfg.PersistRawSecrets = true")
+	}
 
 	if cfg.MaxFileBytes != 1<<20 {
 		t.Fatalf("cfg.MaxFileBytes = %d", cfg.MaxFileBytes)
@@ -61,6 +66,9 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.MaxConfigBytes != 0 {
 		t.Fatalf("cfg.MaxConfigBytes = %d", cfg.MaxConfigBytes)
+	}
+	if cfg.MaxTagResponseBytes != 8*(1<<20) {
+		t.Fatalf("cfg.MaxTagResponseBytes = %d", cfg.MaxTagResponseBytes)
 	}
 	if cfg.TagPageSize != 100 {
 		t.Fatalf("cfg.TagPageSize = %d", cfg.TagPageSize)
@@ -128,6 +136,34 @@ func TestLoadInvalidMaxConfigBytes(t *testing.T) {
 	}
 }
 
+func TestLoadAllowsPersistRawSecretsOptIn(t *testing.T) {
+	t.Setenv("LAYERLEAK_PERSIST_RAW_SECRETS", "1")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !cfg.PersistRawSecrets {
+		t.Fatal("cfg.PersistRawSecrets = false")
+	}
+}
+
+func TestLoadInvalidPersistRawSecrets(t *testing.T) {
+	t.Setenv("LAYERLEAK_PERSIST_RAW_SECRETS", "maybe")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
+func TestLoadInvalidMaxTagResponseBytes(t *testing.T) {
+	t.Setenv("LAYERLEAK_MAX_TAG_RESPONSE_BYTES", "-1")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
 func TestLoadInvalidTagPageSize(t *testing.T) {
 	t.Setenv("LAYERLEAK_TAG_PAGE_SIZE", "0")
 
@@ -143,12 +179,13 @@ func TestLoadAllowsZeroRepositoryLimits(t *testing.T) {
 	t.Setenv("LAYERLEAK_MAX_REPOSITORY_TARGETS", "0")
 	t.Setenv("LAYERLEAK_MAX_MANIFEST_BYTES", "0")
 	t.Setenv("LAYERLEAK_MAX_CONFIG_BYTES", "0")
+	t.Setenv("LAYERLEAK_MAX_TAG_RESPONSE_BYTES", "0")
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if cfg.MaxLayerBytes != 0 || cfg.MaxLayerEntries != 0 || cfg.MaxRepositoryTags != 0 || cfg.MaxRepositoryTargets != 0 || cfg.MaxManifestBytes != 0 || cfg.MaxConfigBytes != 0 {
+	if cfg.MaxLayerBytes != 0 || cfg.MaxLayerEntries != 0 || cfg.MaxRepositoryTags != 0 || cfg.MaxRepositoryTargets != 0 || cfg.MaxManifestBytes != 0 || cfg.MaxConfigBytes != 0 || cfg.MaxTagResponseBytes != 0 {
 		t.Fatalf("cfg = %#v", cfg)
 	}
 }

--- a/internal/limits/limits.go
+++ b/internal/limits/limits.go
@@ -13,6 +13,7 @@ const (
 	KindLayerEntries      Kind = "layer_entries"
 	KindManifestBytes     Kind = "manifest_bytes"
 	KindConfigBytes       Kind = "config_bytes"
+	KindTagResponseBytes  Kind = "tag_response_bytes"
 	KindRepositoryTags    Kind = "repository_tags"
 	KindRepositoryTargets Kind = "repository_targets"
 )
@@ -38,6 +39,8 @@ func (e *ExceededError) Error() string {
 		return fmt.Sprintf("%s exceeded max manifest bytes limit of %d", subject, e.Limit)
 	case KindConfigBytes:
 		return fmt.Sprintf("%s exceeded max config bytes limit of %d", subject, e.Limit)
+	case KindTagResponseBytes:
+		return fmt.Sprintf("%s exceeded max tag response bytes limit of %d", subject, e.Limit)
 	case KindRepositoryTags:
 		return fmt.Sprintf("%s exceeded max repository tags limit of %d", subject, e.Limit)
 	case KindRepositoryTargets:

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -19,21 +19,23 @@ import (
 )
 
 type Options struct {
-	BaseURL          string
-	AuthURL          string
-	HTTPClient       *http.Client
-	RequestAttempts  int
-	MaxManifestBytes int64
+	BaseURL             string
+	AuthURL             string
+	HTTPClient          *http.Client
+	RequestAttempts     int
+	MaxManifestBytes    int64
+	MaxTagResponseBytes int64
 }
 
 type Client struct {
-	baseURL          *url.URL
-	authURL          *url.URL
-	httpClient       *http.Client
-	requestAttempts  int
-	maxManifestBytes int64
-	tokenCache       map[string]string
-	tokenCacheMu     sync.Mutex
+	baseURL             *url.URL
+	authURL             *url.URL
+	httpClient          *http.Client
+	requestAttempts     int
+	maxManifestBytes    int64
+	maxTagResponseBytes int64
+	tokenCache          map[string]string
+	tokenCacheMu        sync.Mutex
 }
 
 type ManifestResponse struct {
@@ -73,12 +75,13 @@ func NewClient(options Options) *Client {
 	}
 
 	return &Client{
-		baseURL:          baseURL,
-		authURL:          authURL,
-		httpClient:       httpClient,
-		requestAttempts:  requestAttempts,
-		maxManifestBytes: options.MaxManifestBytes,
-		tokenCache:       make(map[string]string),
+		baseURL:             baseURL,
+		authURL:             authURL,
+		httpClient:          httpClient,
+		requestAttempts:     requestAttempts,
+		maxManifestBytes:    options.MaxManifestBytes,
+		maxTagResponseBytes: options.MaxTagResponseBytes,
+		tokenCache:          make(map[string]string),
 	}
 }
 
@@ -201,10 +204,14 @@ func (c *Client) ListTags(ctx context.Context, repository string, pageSize, maxT
 			Name string   `json:"name"`
 			Tags []string `json:"tags"`
 		}
-		decodeErr := json.NewDecoder(response.Body).Decode(&payload)
 		linkHeader := response.Header.Get("Link")
+		body, readErr := readTagResponseBody(response.Body, c.maxTagResponseBytes, repository)
 		response.Body.Close()
-		if decodeErr != nil {
+		if readErr != nil {
+			sort.Strings(tags)
+			return tags, readErr
+		}
+		if decodeErr := json.Unmarshal(body, &payload); decodeErr != nil {
 			return nil, fmt.Errorf("decode tags response: %w", decodeErr)
 		}
 
@@ -538,6 +545,27 @@ func readManifestBody(reader io.Reader, maxBytes int64, identifier string) ([]by
 	}
 	if int64(len(body)) > maxBytes {
 		return nil, limits.NewExceeded(limits.KindManifestBytes, maxBytes, "manifest "+strings.TrimSpace(identifier))
+	}
+
+	return body, nil
+}
+
+func readTagResponseBody(reader io.Reader, maxBytes int64, repository string) ([]byte, error) {
+	if maxBytes <= 0 {
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("read tags response: %w", err)
+		}
+		return body, nil
+	}
+
+	limited := io.LimitReader(reader, maxBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read tags response: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, limits.NewExceeded(limits.KindTagResponseBytes, maxBytes, "tag response for repository "+strings.TrimSpace(repository))
 	}
 
 	return body, nil

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -207,6 +207,85 @@ func TestListTagsReturnsPartialTagsWhenLimitExceeded(t *testing.T) {
 	}
 }
 
+func TestListTagsFailsWhenTagResponseExceedsConfiguredBytes(t *testing.T) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return jsonResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return jsonResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		return jsonResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["latest","2.0","1.0"]}`), nil), nil
+	})
+
+	client := NewClient(Options{
+		BaseURL:             "https://registry.test",
+		MaxTagResponseBytes: 12,
+		HTTPClient: &http.Client{
+			Transport: transport,
+		},
+	})
+
+	tags, err := client.ListTags(context.Background(), "library/app", 100, 0)
+	if err == nil {
+		t.Fatal("ListTags() error = nil")
+	}
+	if !strings.Contains(err.Error(), "max tag response bytes limit") {
+		t.Fatalf("err = %v", err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("len(tags) = %d", len(tags))
+	}
+}
+
+func TestListTagsReturnsPartialTagsWhenTagResponseLimitExceededMidPagination(t *testing.T) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return jsonResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return jsonResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		switch request.URL.Query().Get("last") {
+		case "":
+			return jsonResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["2.0","1.0"]}`), map[string]string{
+				"Link": `</v2/library/app/tags/list?n=2&last=2.0>; rel="next"`,
+			}), nil
+		case "2.0":
+			return jsonResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["really-long-tag-name","3.0"]}`), nil), nil
+		default:
+			return jsonResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+		}
+	})
+
+	client := NewClient(Options{
+		BaseURL:             "https://registry.test",
+		MaxTagResponseBytes: 48,
+		HTTPClient: &http.Client{
+			Transport: transport,
+		},
+	})
+
+	tags, err := client.ListTags(context.Background(), "library/app", 2, 0)
+	if err == nil {
+		t.Fatal("ListTags() error = nil")
+	}
+	if !strings.Contains(err.Error(), "max tag response bytes limit") {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.Join(tags, ",") != "1.0,2.0" {
+		t.Fatalf("tags = %q", strings.Join(tags, ","))
+	}
+}
+
 func TestFetchManifestRefreshesExpiredCachedToken(t *testing.T) {
 	tokenRequests := 0
 	authorizedRequests := 0

--- a/internal/scanservice/service.go
+++ b/internal/scanservice/service.go
@@ -130,8 +130,9 @@ func (s *Service) registryClient() *registry.Client {
 	}
 
 	return registry.NewClient(registry.Options{
-		BaseURL: s.config.RegistryBaseURL,
-		AuthURL: s.config.RegistryAuthURL,
+		BaseURL:             s.config.RegistryBaseURL,
+		AuthURL:             s.config.RegistryAuthURL,
+		MaxTagResponseBytes: s.config.MaxTagResponseBytes,
 		HTTPClient: &http.Client{
 			Timeout: s.config.HTTPTimeout,
 		},

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -14,7 +14,8 @@ import (
 )
 
 type PostgresStore struct {
-	db *sql.DB
+	db                *sql.DB
+	persistRawSecrets bool
 }
 
 func NewPostgresStore(config PostgresConfig) (*PostgresStore, error) {
@@ -34,7 +35,10 @@ func NewPostgresStore(config PostgresConfig) (*PostgresStore, error) {
 		return nil, fmt.Errorf("ping postgres: %w", err)
 	}
 
-	return &PostgresStore{db: db}, nil
+	return &PostgresStore{
+		db:                db,
+		persistRawSecrets: config.PersistRawSecrets,
+	}, nil
 }
 
 func (s *PostgresStore) Close() error {
@@ -84,11 +88,11 @@ func (s *PostgresStore) SaveScan(ctx context.Context, record ScanRecord) (int64,
 	}
 
 	for _, item := range findings.DeduplicateDetailed(record.DetailedFindings) {
-		findingID, err := upsertFinding(ctx, tx, item, scannedAt)
+		findingID, err := upsertFinding(ctx, tx, item, scannedAt, s.persistRawSecrets)
 		if err != nil {
 			return 0, err
 		}
-		if err := upsertFindingOccurrence(ctx, tx, findingID, item, scannedAt); err != nil {
+		if err := upsertFindingOccurrence(ctx, tx, findingID, item, scannedAt, s.persistRawSecrets); err != nil {
 			return 0, err
 		}
 	}
@@ -219,7 +223,7 @@ func replaceTagMappings(ctx context.Context, tx *sql.Tx, repositoryID int64, ite
 	return nil
 }
 
-func upsertFinding(ctx context.Context, tx *sql.Tx, item findings.DetailedFinding, scannedAt time.Time) (int64, error) {
+func upsertFinding(ctx context.Context, tx *sql.Tx, item findings.DetailedFinding, scannedAt time.Time, persistRawSecrets bool) (int64, error) {
 	var findingID int64
 	if err := tx.QueryRowContext(ctx, `
 		INSERT INTO findings (
@@ -237,14 +241,14 @@ func upsertFinding(ctx context.Context, tx *sql.Tx, item findings.DetailedFindin
 			value = EXCLUDED.value,
 			last_seen_at = EXCLUDED.last_seen_at
 		RETURNING id
-	`, strings.TrimSpace(item.ManifestDigest), strings.TrimSpace(item.Fingerprint), item.RedactedValue, item.Value, scannedAt).Scan(&findingID); err != nil {
+	`, strings.TrimSpace(item.ManifestDigest), strings.TrimSpace(item.Fingerprint), item.RedactedValue, persistedValue(item, persistRawSecrets), scannedAt).Scan(&findingID); err != nil {
 		return 0, fmt.Errorf("upsert finding %s/%s: %w", item.ManifestDigest, item.Fingerprint, err)
 	}
 
 	return findingID, nil
 }
 
-func upsertFindingOccurrence(ctx context.Context, tx *sql.Tx, findingID int64, item findings.DetailedFinding, scannedAt time.Time) error {
+func upsertFindingOccurrence(ctx context.Context, tx *sql.Tx, findingID int64, item findings.DetailedFinding, scannedAt time.Time, persistRawSecrets bool) error {
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO finding_occurrences (
 			finding_id,
@@ -293,11 +297,27 @@ func upsertFindingOccurrence(ctx context.Context, tx *sql.Tx, findingID int64, i
 			disposition_reason = EXCLUDED.disposition_reason,
 			line_number = EXCLUDED.line_number,
 			last_seen_at = EXCLUDED.last_seen_at
-	`, findingID, item.DetectorName, item.Confidence, string(item.Disposition), string(item.DispositionReason), string(item.SourceType), item.Platform.OS, item.Platform.Architecture, item.Platform.Variant, item.FilePath, item.LayerDigest, item.Key, item.LineNumber, item.ContextSnippet, item.RawSnippet, item.SourceLocation, item.MatchStart, item.MatchEnd, item.PresentInFinalImage, scannedAt); err != nil {
+	`, findingID, item.DetectorName, item.Confidence, string(item.Disposition), string(item.DispositionReason), string(item.SourceType), item.Platform.OS, item.Platform.Architecture, item.Platform.Variant, item.FilePath, item.LayerDigest, item.Key, item.LineNumber, item.ContextSnippet, persistedRawSnippet(item, persistRawSecrets), item.SourceLocation, item.MatchStart, item.MatchEnd, item.PresentInFinalImage, scannedAt); err != nil {
 		return fmt.Errorf("upsert finding occurrence %s/%s: %w", item.ManifestDigest, item.Fingerprint, err)
 	}
 
 	return nil
+}
+
+func persistedValue(item findings.DetailedFinding, persistRawSecrets bool) string {
+	if !persistRawSecrets {
+		return ""
+	}
+
+	return item.Value
+}
+
+func persistedRawSnippet(item findings.DetailedFinding, persistRawSecrets bool) string {
+	if !persistRawSecrets {
+		return ""
+	}
+
+	return item.RawSnippet
 }
 
 func insertScanRun(ctx context.Context, tx *sql.Tx, repositoryID int64, record ScanRecord, scannedAt time.Time) (int64, error) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -178,7 +178,8 @@ var ErrNotFound = errors.New("storage record not found")
 type NoopStore struct{}
 
 type PostgresConfig struct {
-	DatabaseURL string
+	DatabaseURL       string
+	PersistRawSecrets bool
 }
 
 func NewNoopStore() NoopStore {

--- a/internal/storage/storage_integration_test.go
+++ b/internal/storage/storage_integration_test.go
@@ -66,7 +66,7 @@ func TestPostgresStoreSaveScanUpsertsAndRetainsProvenance(t *testing.T) {
 	if err := db.QueryRow("SELECT value FROM findings").Scan(&value); err != nil {
 		t.Fatalf("QueryRow(value) error = %v", err)
 	}
-	if value != "ghp_123456789012345678901234567890123456" {
+	if value != "" {
 		t.Fatalf("value = %q", value)
 	}
 
@@ -74,7 +74,7 @@ func TestPostgresStoreSaveScanUpsertsAndRetainsProvenance(t *testing.T) {
 	if err := db.QueryRow("SELECT raw_snippet FROM finding_occurrences ORDER BY source_location LIMIT 1").Scan(&rawSnippet); err != nil {
 		t.Fatalf("QueryRow(raw_snippet) error = %v", err)
 	}
-	if !strings.Contains(rawSnippet, "ghp_123456789012345678901234567890123456") {
+	if rawSnippet != "" {
 		t.Fatalf("rawSnippet = %q", rawSnippet)
 	}
 
@@ -91,6 +91,44 @@ func TestPostgresStoreSaveScanUpsertsAndRetainsProvenance(t *testing.T) {
 	}
 	if lineNumber <= 0 {
 		t.Fatalf("lineNumber = %d", lineNumber)
+	}
+}
+
+func TestPostgresStoreSaveScanPersistsRawSecretsWhenEnabled(t *testing.T) {
+	db := openIntegrationDB(t)
+	defer db.Close()
+	if err := applyMigrationSet(t, db, "*.up.sql"); err != nil {
+		t.Fatalf("applyMigrationSet() error = %v", err)
+	}
+
+	store, err := NewPostgresStore(PostgresConfig{
+		DatabaseURL:       integrationDatabaseURL(t),
+		PersistRawSecrets: true,
+	})
+	if err != nil {
+		t.Fatalf("NewPostgresStore() error = %v", err)
+	}
+	defer store.Close()
+
+	record := integrationScanRecord(time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC))
+	if _, err := store.SaveScan(context.Background(), record); err != nil {
+		t.Fatalf("SaveScan() error = %v", err)
+	}
+
+	var value string
+	if err := db.QueryRow("SELECT value FROM findings").Scan(&value); err != nil {
+		t.Fatalf("QueryRow(value) error = %v", err)
+	}
+	if value != "ghp_123456789012345678901234567890123456" {
+		t.Fatalf("value = %q", value)
+	}
+
+	var rawSnippet string
+	if err := db.QueryRow("SELECT raw_snippet FROM finding_occurrences ORDER BY source_location LIMIT 1").Scan(&rawSnippet); err != nil {
+		t.Fatalf("QueryRow(raw_snippet) error = %v", err)
+	}
+	if !strings.Contains(rawSnippet, "ghp_123456789012345678901234567890123456") {
+		t.Fatalf("rawSnippet = %q", rawSnippet)
 	}
 }
 


### PR DESCRIPTION
- LAYERLEAK_PERSIST_RAW_SECRETS now defaults to false, and LAYERLEAK_MAX_TAG_RESPONSE_BYTES defaults to 8388608 via internal/config/config.go:11.

- CLI findings files are redacted by default, only include raw value and raw_context_snippet when explicitly opted in, and are written with tighter permissions in internal/cli/results.go:17.

- Postgres persistence now follows the same opt-in rule without a migration by storing empty raw columns unless enabled in internal/storage/postgres.go:16.

- Docker Hub tag pagination is now bounded per page and returns partial tags plus a limit error when the response body is too large in internal/registry/client.go:21 and internal/registry/client.go:183.

- README behavior and env docs were updated in README.md:61.