### PR TITLE
Pages: read Go version from go.mod so the build matches the module toolchain

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,8 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
+          cache: true
 
       - name: Validate repo
         run: go test ./...


### PR DESCRIPTION


The deploy that ran on the merge into main exited 7 seconds in with:

  go: go.mod requires go >= 1.25.7 (running go 1.24.13; GOTOOLCHAIN=local)
  Error: Process completed with exit code 1.

`actions/setup-go@v6` was installing Go 1.24 because the workflow pinned `go-version: '1.24'`, while go.mod declares `go 1.25.7`. setup-go also sets `GOTOOLCHAIN=local`, so `go test ./...` cannot auto-bootstrap to a newer toolchain at run time.

Switch to `go-version-file: go.mod` (matching `.github/workflows/test.yml`, which is green on main). setup-go now reads the module's `go` directive and installs the exact toolchain go.mod asks for, with module cache enabled.

[AI-assisted]