### PR TITLE
Harden repository API path parsing and clarify endpoint usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ Current endpoints:
 - `GET /api/v1/repositories/{repository}/findings`
 - `GET /api/v1/findings/{id}`
 
+Notes:
+- `{repository}` is the repository path segment (for example `library/nginx`) and should be URL-encoded when called from raw HTTP clients.
+- If the same repository name exists on multiple registries, pass `?registry=<host>` (for example `registry=ghcr.io`) to scope scan and finding list responses.
+- Trailing slashes are accepted for the repository list endpoints (for example `/api/v1/repositories/library/nginx/scans/`).
+
 `POST /api/v1/scans` stays synchronous and now returns `scan_run_id` whenever Postgres persistence is enabled.
 API scan responses reuse the same redacted result schema as the CLI JSON output.
 `GET /api/v1/scans/{id}` returns the persisted run metadata plus the stored redacted result snapshot.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -258,10 +258,12 @@ func (h *Handler) handleRepositorySubtree(writer http.ResponseWriter, request *h
 		return
 	}
 
+	path := strings.TrimSuffix(request.URL.Path, "/")
+
 	switch {
-	case strings.HasSuffix(request.URL.Path, "/findings"):
+	case strings.HasSuffix(path, "/findings"):
 		h.handleListRepositoryFindings(writer, request)
-	case strings.HasSuffix(request.URL.Path, "/scans"):
+	case strings.HasSuffix(path, "/scans"):
 		h.handleListRepositoryScans(writer, request)
 	default:
 		http.NotFound(writer, request)
@@ -285,7 +287,7 @@ func (h *Handler) handleListRepositoryScans(writer http.ResponseWriter, request 
 		return
 	}
 
-	registry := request.URL.Query().Get("registry")
+	registry := strings.TrimSpace(request.URL.Query().Get("registry"))
 	items, err := h.store.ListRepositoryScans(request.Context(), registry, repository, limit, offset)
 	if err != nil {
 		writeAPIError(writer, http.StatusInternalServerError, "internal_error", err.Error())
@@ -327,7 +329,7 @@ func (h *Handler) handleListRepositoryFindings(writer http.ResponseWriter, reque
 		return
 	}
 
-	registry := request.URL.Query().Get("registry")
+	registry := strings.TrimSpace(request.URL.Query().Get("registry"))
 	items, err := h.store.ListRepositoryFindings(request.Context(), registry, repository, disposition, limit, offset)
 	if err != nil {
 		writeAPIError(writer, http.StatusInternalServerError, "internal_error", err.Error())
@@ -480,7 +482,8 @@ func repositoryPathValue(path, suffix string) (string, bool, error) {
 		return "", false, nil
 	}
 
-	rawRepository := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	normalizedPath := strings.TrimSuffix(path, "/")
+	rawRepository := strings.TrimSuffix(strings.TrimPrefix(normalizedPath, prefix), suffix)
 	repository, err := url.PathUnescape(strings.Trim(rawRepository, "/"))
 	if err != nil {
 		return "", false, fmt.Errorf("repository path is invalid")

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -255,6 +255,43 @@ func TestHandleListRepositoryFindingsForwardsRegistryQuery(t *testing.T) {
 	}
 }
 
+func TestHandleListRepositoryScansAllowsTrailingSlash(t *testing.T) {
+	store := &stubReadStore{}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/library/app/scans/?registry=%20docker.io%20", nil)
+	recorder := httptest.NewRecorder()
+
+	NewHandler(&stubScanner{}, store).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if store.registry != "docker.io" {
+		t.Fatalf("store.registry = %q", store.registry)
+	}
+	if store.repository != "library/app" {
+		t.Fatalf("store.repository = %q", store.repository)
+	}
+}
+
+func TestHandleListRepositoryFindingsAllowsTrailingSlash(t *testing.T) {
+	store := &stubReadStore{}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/prometheus/busybox/findings/?registry=%20quay.io%20", nil)
+	recorder := httptest.NewRecorder()
+
+	NewHandler(&stubScanner{}, store).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if store.registry != "quay.io" {
+		t.Fatalf("store.registry = %q", store.registry)
+	}
+	if store.repository != "prometheus/busybox" {
+		t.Fatalf("store.repository = %q", store.repository)
+	}
+}
 func TestHandleGetScanReturnsDetail(t *testing.T) {
 	store := &stubReadStore{
 		scanDetail: storage.ScanRunDetail{


### PR DESCRIPTION
### Motivation
- Fix a bug where repository list endpoints returned `404` when called with a trailing slash due to strict suffix matching. 
- Prevent subtle mismatches when callers send `registry` query values with surrounding whitespace (for example `%20ghcr.io%20`).
- Make API behavior clearer in the docs so clients know to URL-encode repository segments and that trailing slashes are accepted.

### Description
- Normalize the request path by trimming a trailing slash in `handleRepositorySubtree` so `.../scans/` and `.../findings/` are recognized. 
- Normalize repository extraction in `repositoryPathValue` by trimming a trailing slash before unescaping the repository segment. 
- Trim surrounding whitespace from the `registry` query parameter with `strings.TrimSpace` before forwarding to the store. 
- Add two unit tests `TestHandleListRepositoryScansAllowsTrailingSlash` and `TestHandleListRepositoryFindingsAllowsTrailingSlash` to cover trailing-slash handling and whitespace-trimmed `registry` values. 
- Update `README.md` to document URL-encoding of `{repository}`, optional `?registry=` scoping, and accepted trailing-slash behavior for repository endpoints.

### Testing
- Attempted `go test ./internal/api -count=1`, but the test run timed out in this environment (`EXIT:124`).
- Attempted `go test ./... -count=1`, but the run timed out in this environment (`EXIT:124`).
- Ran `gofmt -w` on modified files to ensure formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41a3d03408322b9e62e96871831f6)