### PR TITLE
Improve error handling and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,24 +108,30 @@ export LAYERLEAK_REGISTRY_AUTH_URL=
 export LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?sslmode=disable
 ```
 
-The full set of supported variables and their defaults also lives in [`.env.example`](./.env.example).
-`LAYERLEAK_LOG_LEVEL` accepts `debug`, `info`, `warn`, or `error` and defaults to `info`.
+The same variables and their defaults live in [`.env.example`](./.env.example), which is the source of truth for default values.
 
-If `LAYERLEAK_FINDINGS_DIR` is not set, layerleak writes JSON findings files to `findings/` under the nearest parent directory containing `go.mod` (typically the repo root). If no repo root can be discovered, it falls back to the current working directory.
-Saved findings files contain only detections and are redacted by default.
-Set `LAYERLEAK_PERSIST_RAW_SECRETS=1` only if you explicitly want raw finding values and raw context snippets written to disk and Postgres.
-`LAYERLEAK_TAG_PAGE_SIZE` controls registry tag-list pagination for repository-wide scans.
-`LAYERLEAK_MAX_LAYER_BYTES` defaults to `536870912` (512 MiB) of decompressed layer stream data per layer, and `LAYERLEAK_MAX_LAYER_ENTRIES` defaults to `50000` tar entries per layer.
-`LAYERLEAK_MAX_TAG_RESPONSE_BYTES` defaults to `8388608` (8 MiB) per registry tag-list response page.
-`LAYERLEAK_REGISTRY_BASE_URL` and `LAYERLEAK_REGISTRY_AUTH_URL` are optional overrides. Leave them unset for normal use — layerleak derives the registry base URL from each image reference and discovers the auth realm from the registry's `WWW-Authenticate` challenge. Set them only to force scans through a proxy or alternate endpoint.
-`LAYERLEAK_MAX_LAYER_BYTES`, `LAYERLEAK_MAX_LAYER_ENTRIES`, `LAYERLEAK_MAX_MANIFEST_BYTES`, `LAYERLEAK_MAX_CONFIG_BYTES`, `LAYERLEAK_MAX_TAG_RESPONSE_BYTES`, `LAYERLEAK_MAX_REPOSITORY_TAGS`, and `LAYERLEAK_MAX_REPOSITORY_TARGETS` are disabled when set to `0`.
-If enabled, those limits fail the scan with a clear error instead of silently truncating work.
-`LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS` controls registry request retries and defaults to `2`.
-`LAYERLEAK_HTTP_TIMEOUT` is the per-request timeout applied to the HTTP client used for every registry call (manifest fetches, blob downloads, tag list pages, auth token requests). Accepts any Go duration value (`30s`, `2m`, `1h`); defaults to `30s`.
-`LAYERLEAK_MAX_FILE_BYTES` is the maximum decompressed bytes layerleak buffers per file inside a layer; files larger than this are classified as oversize and skipped. Defaults to `1048576` (1 MiB) and must be greater than zero.
-`LAYERLEAK_API_ADDR` controls the bind address for the API server and defaults to `127.0.0.1:8080` in local binaries.
-The container image overrides this to `0.0.0.0:8080`.
-If `LAYERLEAK_DATABASE_URL` is set, the scanner also writes the scan to Postgres and fails the command if Postgres is unavailable or the save does not succeed.
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `LAYERLEAK_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, or `error`. |
+| `LAYERLEAK_FINDINGS_DIR` | _unset_ | Where to write JSON findings files. If unset, defaults to `findings/` under the nearest parent containing `go.mod`, falling back to the current working directory. |
+| `LAYERLEAK_API_ADDR` | `127.0.0.1:8080` | Bind address for the API server. The container image overrides this to `0.0.0.0:8080`. |
+| `LAYERLEAK_PERSIST_RAW_SECRETS` | `0` | Set to `1` to write raw secret values and raw context snippets to disk and Postgres. Findings stay redacted by default. |
+| `LAYERLEAK_HTTP_TIMEOUT` | `30s` | Per-request timeout for every registry call (manifests, blobs, tag pages, auth tokens). Accepts any Go duration (`30s`, `2m`, `1h`). |
+| `LAYERLEAK_MAX_FILE_BYTES` | `1048576` (1 MiB) | Max decompressed bytes buffered per file inside a layer. Files larger than this are skipped as oversize. Must be greater than zero. |
+| `LAYERLEAK_MAX_LAYER_BYTES` | `536870912` (512 MiB) | Max decompressed layer stream bytes per layer. `0` disables the limit. |
+| `LAYERLEAK_MAX_LAYER_ENTRIES` | `50000` | Max tar entries per layer. `0` disables the limit. |
+| `LAYERLEAK_MAX_MANIFEST_BYTES` | `0` | Max manifest body bytes. `0` disables the limit. |
+| `LAYERLEAK_MAX_CONFIG_BYTES` | `0` | Max image config body bytes. `0` disables the limit. |
+| `LAYERLEAK_MAX_TAG_RESPONSE_BYTES` | `8388608` (8 MiB) | Max bytes per registry tag-list response page. `0` disables the limit. |
+| `LAYERLEAK_TAG_PAGE_SIZE` | `100` | Registry tag-list page size for repository-wide scans. |
+| `LAYERLEAK_MAX_REPOSITORY_TAGS` | `0` | Max tags enumerated per repository scan. `0` disables the limit. |
+| `LAYERLEAK_MAX_REPOSITORY_TARGETS` | `0` | Max distinct targets resolved per repository scan. `0` disables the limit. |
+| `LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS` | `2` | Number of attempts (including the first) for each registry request. |
+| `LAYERLEAK_REGISTRY_BASE_URL` | _unset_ | Optional override. Normally layerleak derives this from each image reference; set only to force scans through a proxy or alternate endpoint. |
+| `LAYERLEAK_REGISTRY_AUTH_URL` | _unset_ | Optional override. Normally discovered from the registry's `WWW-Authenticate` challenge. |
+| `LAYERLEAK_DATABASE_URL` | _unset_ | If set, layerleak writes scans to Postgres and fails the command if persistence does not succeed. |
+
+When any of the `MAX_*` limits is set to a positive value, exceeding it fails the scan with a clear error instead of silently truncating work.
 
 Result behavior:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,18 @@ When reporting, include:
 - any relevant image reference, digest, or file path
 
 Do not publish proof-of-concept details or active secrets before the issue has been reviewed.
+
+## Coordinated disclosure
+
+We aim to acknowledge new reports within 7 days and ship a fix or mitigation within 90 days of acknowledgement. If a report blocks on upstream work (for example, a fix in `github.com/trufflesecurity/trufflehog`), we will keep the reporter updated on progress and credit them in the release notes once the fix lands.
+
+Please give us a reasonable window before public disclosure. If 90 days pass without a fix or status update from us, you are free to disclose.
+
+## Supported versions
+
+Only the latest tagged release on `main` receives security patches. Older `v1.x` tags are not patched in place; upgrade to the latest release to pick up fixes.
+
+| Version    | Supported          |
+| ---------- | ------------------ |
+| latest tag | yes                |
+| older tags | no — please upgrade |

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -56,11 +56,13 @@ func newScanCmd() *cobra.Command {
 
 			store, err := newStore(cfg)
 			if err != nil {
-				_ = progress.Update(progressSnapshot{
+				if updateErr := progress.Update(progressSnapshot{
 					repository: ref.Repository,
 					phase:      "Error",
 					message:    err.Error(),
-				})
+				}); updateErr != nil {
+					logger.Debug("progress update failed", "error", updateErr)
+				}
 				return err
 			}
 			if closer, ok := store.(interface{ Close() error }); ok {
@@ -73,7 +75,9 @@ func newScanCmd() *cobra.Command {
 				Platform:  platform,
 				Logger:    logger,
 				Progress: func(update jobs.ProgressUpdate) {
-					_ = progress.UpdateFromJob(update)
+					if err := progress.UpdateFromJob(update); err != nil {
+						logger.Debug("progress update failed", "error", err)
+					}
 				},
 				BeforeSave: func(result jobs.Result) error {
 					if store.Name() == "noop" {
@@ -97,15 +101,17 @@ func newScanCmd() *cobra.Command {
 			scanErr := err
 			limitExceeded := limits.IsExceeded(scanErr)
 			if scanErr != nil && !limitExceeded {
-				_ = progress.Update(progressSnapshot{
+				if updateErr := progress.Update(progressSnapshot{
 					repository: ref.Repository,
 					phase:      "Error",
 					message:    scanErr.Error(),
-				})
+				}); updateErr != nil {
+					logger.Debug("progress update failed", "error", updateErr)
+				}
 				return scanErr
 			}
 			if scanErr != nil {
-				_ = progress.Update(progressSnapshot{
+				if updateErr := progress.Update(progressSnapshot{
 					repository:       ref.Repository,
 					tagsCompleted:    result.TagsResolved,
 					tagsFailed:       result.TagsFailed,
@@ -116,7 +122,9 @@ func newScanCmd() *cobra.Command {
 					findingsFound:    result.TotalFindings,
 					phase:            "Error",
 					message:          scanErr.Error(),
-				})
+				}); updateErr != nil {
+					logger.Debug("progress update failed", "error", updateErr)
+				}
 			}
 
 			if err := progress.Update(progressSnapshot{
@@ -136,7 +144,7 @@ func newScanCmd() *cobra.Command {
 
 			resultPath, err := writeResultFile(cfg.FindingsDir, cfg.PersistRawSecrets, result)
 			if err != nil {
-				_ = progress.Update(progressSnapshot{
+				if updateErr := progress.Update(progressSnapshot{
 					repository:       ref.Repository,
 					tagsCompleted:    result.TagsResolved,
 					tagsFailed:       result.TagsFailed,
@@ -147,7 +155,9 @@ func newScanCmd() *cobra.Command {
 					findingsFound:    result.TotalFindings,
 					phase:            "Error",
 					message:          err.Error(),
-				})
+				}); updateErr != nil {
+					logger.Debug("progress update failed", "error", updateErr)
+				}
 				return err
 			}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -213,3 +213,43 @@ func TestLoadInvalidRegistryRequestAttempts(t *testing.T) {
 		t.Fatal("Load() error = nil")
 	}
 }
+
+func TestLoadRejectsNonNumericMaxFileBytes(t *testing.T) {
+	t.Setenv("LAYERLEAK_MAX_FILE_BYTES", "abc")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil")
+	}
+}
+
+func TestLoadTrimsFindingsDirAndDatabaseURL(t *testing.T) {
+	t.Setenv("LAYERLEAK_FINDINGS_DIR", "  /tmp/findings  ")
+	t.Setenv("LAYERLEAK_DATABASE_URL", "  postgres://localhost/db  ")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.FindingsDir != "/tmp/findings" {
+		t.Fatalf("cfg.FindingsDir = %q", cfg.FindingsDir)
+	}
+	if cfg.DatabaseURL != "postgres://localhost/db" {
+		t.Fatalf("cfg.DatabaseURL = %q", cfg.DatabaseURL)
+	}
+}
+
+func TestLoadOverridesLogLevelAndAPIAddr(t *testing.T) {
+	t.Setenv("LAYERLEAK_LOG_LEVEL", "debug")
+	t.Setenv("LAYERLEAK_API_ADDR", "0.0.0.0:9090")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Fatalf("cfg.LogLevel = %q", cfg.LogLevel)
+	}
+	if cfg.APIAddr != "0.0.0.0:9090" {
+		t.Fatalf("cfg.APIAddr = %q", cfg.APIAddr)
+	}
+}

--- a/revive.toml
+++ b/revive.toml
@@ -2,3 +2,7 @@ enableDefaultRules = true
 
 [rule.exported]
 Disabled = true
+
+[rule.early-return]
+
+[rule.bool-literal-in-expr]


### PR DESCRIPTION
## Summary
This PR improves error handling in the scan command, enhances configuration documentation, expands security policy, and enables additional linting rules.

## Key Changes

### Error Handling (`internal/cli/scan.go`)
- Replace ignored error returns (`_ = progress.Update(...)`) with proper error handling
- Log progress update failures at debug level instead of silently discarding them
- Applies to all progress update calls throughout the scan command flow

### Documentation (`README.md`)
- Convert environment variable documentation from prose to a structured table format
- Clarify that `.env.example` is the source of truth for default values
- Improve readability and scannability of configuration options
- Add explicit note about limit behavior: when set to positive values, limits fail the scan with clear errors instead of silently truncating

### Security Policy (`SECURITY.md`)
- Add coordinated disclosure section with 7-day acknowledgement and 90-day fix targets
- Document supported versions policy: only latest tagged release receives patches
- Add version support table for clarity

### Configuration Tests (`internal/config/config_test.go`)
- Add test for rejecting non-numeric `LAYERLEAK_MAX_FILE_BYTES` values
- Add test for trimming whitespace from `LAYERLEAK_FINDINGS_DIR` and `LAYERLEAK_DATABASE_URL`
- Add test for overriding `LAYERLEAK_LOG_LEVEL` and `LAYERLEAK_API_ADDR`

### Linting (`revive.toml`)
- Enable `early-return` rule to encourage early returns and reduce nesting
- Enable `bool-literal-in-expr` rule to catch unnecessary boolean literal comparisons

## Notable Details
- Progress update error handling is consistent across all code paths (store creation, job progress, scan errors, and result file writing)
- Debug-level logging for progress failures prevents noise in normal operation while aiding troubleshooting
- Documentation changes make configuration more discoverable and reduce ambiguity around default behaviors

https://claude.ai/code/session_0141u5RpVat3vbY4fKUUTbrX