### PR TITLE
feat: add 6 new secret detectors and API health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,16 @@ docker run --rm \
 
 Current endpoints:
 
+- `GET /health`
 - `POST /api/v1/scans`
 - `GET /api/v1/scans/{id}`
 - `GET /api/v1/repositories`
 - `GET /api/v1/repositories/{repository}/scans`
 - `GET /api/v1/repositories/{repository}/findings`
 - `GET /api/v1/findings/{id}`
+
+`GET /health` returns `{"status":"ok"}` and does not require a configured store or scanner.
+It is suitable for Kubernetes readiness probes and Docker Compose `healthcheck` targets.
 
 `POST /api/v1/scans` stays synchronous and now returns `scan_run_id` whenever Postgres persistence is enabled.
 API scan responses reuse the same redacted result schema as the CLI JSON output.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -163,12 +163,17 @@ func NewHandler(scanner scanExecutor, store storage.ReadStore) http.Handler {
 	}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", handler.handleHealth)
 	mux.HandleFunc("POST /api/v1/scans", handler.handleScan)
 	mux.HandleFunc("GET /api/v1/scans/{id}", handler.handleGetScan)
 	mux.HandleFunc("GET /api/v1/repositories", handler.handleListRepositories)
 	mux.HandleFunc("GET /api/v1/repositories/", handler.handleRepositorySubtree)
 	mux.HandleFunc("GET /api/v1/findings/{id}", handler.handleGetFinding)
 	return mux
+}
+
+func (h *Handler) handleHealth(writer http.ResponseWriter, _ *http.Request) {
+	writeJSON(writer, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func (h *Handler) handleScan(writer http.ResponseWriter, request *http.Request) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -18,6 +18,20 @@ import (
 	"github.com/brumbelow/layerleak/internal/storage"
 )
 
+func TestHandleHealthReturnsOK(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	recorder := httptest.NewRecorder()
+
+	NewHandler(&stubScanner{}, &stubReadStore{}).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), `"status": "ok"`) {
+		t.Fatalf("body = %s", recorder.Body.String())
+	}
+}
+
 func TestHandleScanSuccess(t *testing.T) {
 	scanner := &stubScanner{
 		outcome: scanservice.Outcome{

--- a/internal/detectors/detectors.go
+++ b/internal/detectors/detectors.go
@@ -84,6 +84,12 @@ func Default() Set {
 			newPathRegexDetector("netrc_password", regexp.MustCompile(`(^|/)\.netrc$`), regexp.MustCompile(`(?im)\bpassword\s+([^\s#]+)`), 1, ConfidenceMedium, hasMinPrintableLength(4)),
 			newPathRegexDetector("pypirc_password", regexp.MustCompile(`(^|/)\.pypirc$`), regexp.MustCompile(`(?im)^\s*password\s*=\s*([^\s#;]+)\s*$`), 1, ConfidenceMedium, hasMinPrintableLength(4)),
 			newRegexDetector("basic_auth_url", regexp.MustCompile(`https?://[^/\s:@]+:[^/\s@]+@[^/\s]+`), 0, ConfidenceHigh, looksLikeBasicAuthURL),
+			newRegexDetector("huggingface_token", regexp.MustCompile(`\bhf_[A-Za-z0-9]{34,}\b`), 0, ConfidenceHigh, nil),
+			newRegexDetector("digitalocean_pat", regexp.MustCompile(`\bdop_v1_[a-f0-9]{64}\b`), 0, ConfidenceHigh, nil),
+			newRegexDetector("mailchimp_api_key", regexp.MustCompile(`\b[0-9a-f]{32}-us[0-9]{1,2}\b`), 0, ConfidenceHigh, nil),
+			newRegexDetector("hashicorp_vault_token", regexp.MustCompile(`\b(?:hvs|hvb|hvr)\.[A-Za-z0-9_-]{24,}\b`), 0, ConfidenceHigh, nil),
+			newPathRegexDetector("kubeconfig_token", regexp.MustCompile(`(^|/)\.kube/config$`), regexp.MustCompile(`(?im)^\s+token:\s+([^\s#]+)\s*$`), 1, ConfidenceHigh, hasMinPrintableLength(8)),
+			newPathRegexDetector("vault_token_file", regexp.MustCompile(`(^|/)\.vault-token$`), regexp.MustCompile(`((?:hvs|hvb|hvr)\.[A-Za-z0-9_-]{24,}|s\.[A-Za-z0-9]{24,})`), 0, ConfidenceHigh, hasMinPrintableLength(24)),
 			contextEntropyDetector{},
 		},
 	}
@@ -221,7 +227,9 @@ func (d pathRegexDetector) Scan(input ScanInput) []Match {
 		d.name == "npmrc_auth_token" ||
 		d.name == "npmrc_auth" ||
 		d.name == "netrc_password" ||
-		d.name == "pypirc_password" {
+		d.name == "pypirc_password" ||
+		d.name == "kubeconfig_token" ||
+		d.name == "vault_token_file" {
 		priority = priorityStructured
 	}
 	return scanRegexMatches(d.name, d.expression, d.group, d.base, priority, d.validator, input)

--- a/internal/detectors/detectors_test.go
+++ b/internal/detectors/detectors_test.go
@@ -108,6 +108,50 @@ func TestDefaultSetScan(t *testing.T) {
 			},
 			wantDetector: "basic_auth_url",
 		},
+		{
+			name: "huggingface token",
+			input: ScanInput{
+				Content: "HF_TOKEN=hf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			wantDetector: "huggingface_token",
+		},
+		{
+			name: "digitalocean pat",
+			input: ScanInput{
+				Content: "DO_TOKEN=dop_v1_" + strings.Repeat("0", 64),
+			},
+			wantDetector: "digitalocean_pat",
+		},
+		{
+			name: "mailchimp api key",
+			input: ScanInput{
+				Content: "MC_API_KEY=" + strings.Repeat("0", 32) + "-us1",
+			},
+			wantDetector: "mailchimp_api_key",
+		},
+		{
+			name: "hashicorp vault service token",
+			input: ScanInput{
+				Content: "VAULT_TOKEN=hvs." + strings.Repeat("a", 24),
+			},
+			wantDetector: "hashicorp_vault_token",
+		},
+		{
+			name: "kubeconfig token",
+			input: ScanInput{
+				Path:    "/root/.kube/config",
+				Content: "    token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.signaturetoken",
+			},
+			wantDetector: "kubeconfig_token",
+		},
+		{
+			name: "vault token file hvs",
+			input: ScanInput{
+				Path:    "/root/.vault-token",
+				Content: "hvs." + strings.Repeat("a", 24),
+			},
+			wantDetector: "vault_token_file",
+		},
 	}
 
 	set := Default()
@@ -235,6 +279,22 @@ func TestFileSpecificDetectorsRequireExpectedPath(t *testing.T) {
 				Content: "machine example.com login deploy password supersecretvalue",
 			},
 			wantDetector: "netrc_password",
+		},
+		{
+			name: "kubeconfig token on wrong path",
+			input: ScanInput{
+				Path:    "/tmp/config.txt",
+				Content: "    token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.signaturetoken",
+			},
+			wantDetector: "kubeconfig_token",
+		},
+		{
+			name: "vault token file on wrong path",
+			input: ScanInput{
+				Path:    "/tmp/token.txt",
+				Content: "hvs." + strings.Repeat("a", 24),
+			},
+			wantDetector: "vault_token_file",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- **6 new secret detectors** — covering credential formats that were previously only caught (at lower priority/confidence) by the TruffleHog fallback:
  - `huggingface_token` — `hf_[A-Za-z0-9]{34,}` (ConfidenceHigh, priorityLocal)
  - `digitalocean_pat` — `dop_v1_[a-f0-9]{64}` (ConfidenceHigh, priorityLocal)
  - `mailchimp_api_key` — `[0-9a-f]{32}-us[0-9]{1,2}` (ConfidenceHigh, priorityLocal)
  - `hashicorp_vault_token` — `hvs.|hvb.|hvr.[A-Za-z0-9_-]{24,}` (ConfidenceHigh, priorityLocal)
  - `kubeconfig_token` — path-specific to `~/.kube/config`, extracts `token:` field values (ConfidenceHigh, priorityStructured)
  - `vault_token_file` — path-specific to `~/.vault-token`, matches `hvs./hvb./hvr./s.` formats (ConfidenceHigh, priorityStructured)

- **API health check endpoint** — `GET /health` returns `{"status":"ok"}` with no dependency on the store or scanner. Suitable for Kubernetes readiness probes and Docker Compose `healthcheck` targets. Documented in README.

## Design notes

The new regex detectors follow the same pattern as the existing `github_token`, `gitlab_token`, `stripe_key`, etc.: they run at `priorityLocal` (above the TruffleHog fallback) and are deduplicated with TruffleHog's version of the same match by value/span, so there's no double-reporting.

The two path-specific detectors follow the existing `npmrc_auth_token`, `netrc_password`, `aws_shared_credentials` pattern: they only fire on the expected file path, giving them `priorityStructured` to rank above generic regex matches in deduplication.

Test values use low-entropy synthetic strings (e.g. `strings.Repeat("0", 64)`) to avoid triggering GitHub push protection while still exercising the regex.

## Test plan

- [ ] `go test -short ./...` — all 15 packages pass
- [ ] `TestDefaultSetScan` now includes 6 new sub-cases (all green)
- [ ] `TestFileSpecificDetectorsRequireExpectedPath` now includes path-restriction cases for `kubeconfig_token` and `vault_token_file`
- [ ] `TestHandleHealthReturnsOK` covers the new endpoint

AI-assisted commit.

https://claude.ai/code/session_019ezZHqGvVRGxRrLxC75jHw

---
_Generated by [Claude Code](https://claude.ai/code/session_019ezZHqGvVRGxRrLxC75jHw)_