### PR TITLE
Refresh docs page

### DIFF
--- a/web/assets/styles.css
+++ b/web/assets/styles.css
@@ -1,20 +1,20 @@
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap");
 
 :root {
-  --paper: #f6f0e6;
-  --paper-strong: #fffaf1;
-  --ink: #18222d;
-  --ink-soft: #4f5f6d;
-  --line: rgba(24, 34, 45, 0.12);
-  --accent: #c14f2b;
-  --accent-deep: #8f3112;
-  --signal: #0f766e;
-  --signal-soft: rgba(15, 118, 110, 0.12);
-  --warn: #b55b14;
-  --shadow: 0 20px 50px rgba(24, 34, 45, 0.12);
-  --radius-lg: 28px;
-  --radius-md: 18px;
-  --radius-sm: 12px;
+  --paper: #f4f5ef;
+  --paper-strong: #ffffff;
+  --ink: #17202a;
+  --ink-soft: #526071;
+  --line: rgba(23, 32, 42, 0.14);
+  --accent: #b84625;
+  --accent-deep: #762c18;
+  --signal: #0b6f63;
+  --signal-soft: rgba(11, 111, 99, 0.12);
+  --warn: #a65a0a;
+  --shadow: 0 18px 44px rgba(23, 32, 42, 0.1);
+  --radius-lg: 8px;
+  --radius-md: 8px;
+  --radius-sm: 6px;
   --content: 1160px;
 }
 
@@ -31,9 +31,9 @@ html {
 body {
   margin: 0;
   background:
-    radial-gradient(circle at top left, rgba(193, 79, 43, 0.14), transparent 36%),
-    radial-gradient(circle at top right, rgba(15, 118, 110, 0.12), transparent 34%),
-    linear-gradient(180deg, #fcf6ed 0%, #f6f0e6 52%, #efe3d2 100%);
+    linear-gradient(90deg, rgba(23, 32, 42, 0.035) 1px, transparent 1px),
+    linear-gradient(180deg, #fbfbf7 0%, var(--paper) 56%, #e7ece6 100%);
+  background-size: 44px 44px, auto;
   color: var(--ink);
   font-family: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -65,33 +65,6 @@ pre,
   overflow: hidden;
 }
 
-.site-shell::before,
-.site-shell::after {
-  content: "";
-  position: fixed;
-  inset: auto;
-  pointer-events: none;
-  z-index: -1;
-  border-radius: 999px;
-  filter: blur(16px);
-}
-
-.site-shell::before {
-  width: 22rem;
-  height: 22rem;
-  top: 4rem;
-  left: -6rem;
-  background: rgba(193, 79, 43, 0.12);
-}
-
-.site-shell::after {
-  width: 26rem;
-  height: 26rem;
-  right: -8rem;
-  bottom: 10rem;
-  background: rgba(15, 118, 110, 0.12);
-}
-
 .site-header,
 .site-footer,
 .page-section,
@@ -118,7 +91,7 @@ pre,
 .brand-badge {
   width: 3rem;
   height: 3rem;
-  border-radius: 1rem;
+  border-radius: var(--radius-lg);
   display: grid;
   place-items: center;
   font-size: 0.86rem;
@@ -136,7 +109,7 @@ pre,
 .doc-block h2,
 .doc-block h3,
 .demo-panel h2 {
-  letter-spacing: -0.03em;
+  letter-spacing: 0;
 }
 
 .brand-copy {
@@ -633,6 +606,187 @@ pre,
   text-align: center;
 }
 
+.docs-page .site-header {
+  border-bottom: 1px solid var(--line);
+}
+
+.docs-hero {
+  width: min(calc(100% - 2rem), var(--content));
+  margin: 3rem auto 1.2rem;
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 0.8fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.docs-hero-copy {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.docs-hero h1 {
+  max-width: 12ch;
+  margin: 0;
+  font-size: clamp(3rem, 7vw, 6.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+
+.docs-hero p {
+  max-width: 45rem;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 1.08rem;
+}
+
+.layer-map {
+  min-height: 32rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(90deg, rgba(23, 32, 42, 0.07) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(23, 32, 42, 0.05) 1px, transparent 1px),
+    rgba(255, 255, 255, 0.72);
+  background-size: 24px 24px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 0.8rem;
+  position: relative;
+}
+
+.layer-node {
+  padding: 1rem;
+  border: 1px solid var(--line);
+  background: var(--paper-strong);
+  box-shadow: var(--shadow);
+}
+
+.layer-node span,
+.docs-status-strip span,
+.doc-heading span {
+  display: block;
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--signal);
+}
+
+.layer-node strong {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 1.08rem;
+}
+
+.layer-rail {
+  width: 2px;
+  background: linear-gradient(180deg, var(--accent), var(--signal));
+  justify-self: center;
+}
+
+.layer-stack {
+  position: absolute;
+  inset: 6.4rem 2rem 6.4rem;
+  display: grid;
+  align-content: center;
+  gap: 0.65rem;
+}
+
+.layer-stack span {
+  width: min(100%, calc(72% + (var(--i) * 5%)));
+  margin-left: calc(var(--i) * 1.2rem);
+  padding: 0.78rem 0.9rem;
+  border: 1px solid rgba(23, 32, 42, 0.18);
+  background: rgba(244, 245, 239, 0.9);
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.86rem;
+  box-shadow: 7px 7px 0 rgba(11, 111, 99, 0.1);
+}
+
+.docs-status-strip {
+  width: min(calc(100% - 2rem), var(--content));
+  margin: 0 auto 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.docs-status-strip div {
+  min-width: 0;
+  padding: 1rem;
+  border-right: 1px solid var(--line);
+}
+
+.docs-status-strip div:last-child {
+  border-right: 0;
+}
+
+.docs-status-strip strong {
+  display: block;
+  margin-top: 0.35rem;
+  overflow-wrap: anywhere;
+}
+
+.docs-page .docs-shell {
+  align-items: start;
+}
+
+.docs-page .docs-nav,
+.docs-page .doc-block {
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid var(--line);
+  box-shadow: none;
+}
+
+.docs-page .doc-block {
+  padding: 1.35rem;
+}
+
+.doc-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+}
+
+.doc-heading h2 {
+  margin: 0;
+}
+
+.docs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.docs-grid article {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  background: rgba(244, 245, 239, 0.7);
+}
+
+.docs-grid h3 {
+  margin-top: 0;
+}
+
+.result-schema {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.result-schema span {
+  padding: 0.42rem 0.62rem;
+  border: 1px solid rgba(11, 111, 99, 0.2);
+  background: var(--signal-soft);
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.82rem;
+}
+
 .site-footer {
   padding: 1rem 0 2.5rem;
   color: var(--ink-soft);
@@ -655,7 +809,8 @@ pre,
 
 @media (max-width: 1024px) {
   .hero,
-  .docs-shell {
+  .docs-shell,
+  .docs-hero {
     grid-template-columns: 1fr;
   }
 
@@ -665,14 +820,26 @@ pre,
 
   .card-grid,
   .note-grid,
-  .stat-grid {
+  .stat-grid,
+  .docs-status-strip,
+  .docs-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .docs-status-strip div:nth-child(2) {
+    border-right: 0;
+  }
+
+  .docs-status-strip div:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--line);
   }
 }
 
 @media (max-width: 720px) {
   .site-header,
   .hero,
+  .docs-hero,
+  .docs-status-strip,
   .page-section,
   .docs-shell,
   .demo-layout,
@@ -696,8 +863,41 @@ pre,
 
   .card-grid,
   .note-grid,
-  .stat-grid {
+  .stat-grid,
+  .docs-status-strip,
+  .docs-grid {
     grid-template-columns: 1fr;
+  }
+
+  .docs-hero {
+    margin-top: 1.7rem;
+  }
+
+  .docs-hero h1 {
+    font-size: clamp(2.6rem, 15vw, 4.2rem);
+  }
+
+  .layer-map {
+    min-height: 26rem;
+  }
+
+  .layer-stack {
+    inset: 6.3rem 1rem 6.3rem;
+  }
+
+  .layer-stack span {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .docs-status-strip div,
+  .docs-status-strip div:nth-child(2) {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .docs-status-strip div:last-child {
+    border-bottom: 0;
   }
 
   .terminal-screen {

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -1,240 +1,278 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>layerleak Docs</title>
     <meta
       name="description"
-      content="Installation, CLI usage, Postgres persistence, and API docs for layerleak."
-    />
-    <link rel="stylesheet" href="../assets/styles.css" />
+      content="Install, operate, and deploy layerleak, a daemonless OCI image secret scanner."
+    >
+    <link rel="stylesheet" href="../assets/styles.css">
     <script defer src="../assets/site.js"></script>
   </head>
   <body data-page="docs">
-    <div class="site-shell">
+    <div class="site-shell docs-page">
       <header class="site-header">
         <a class="brand-lockup" href="./">
-          <span class="brand-badge">://</span>
+          <span class="brand-badge">LL</span>
           <span class="brand-copy">
             <strong>layerleak</strong>
-            <span>Multi-registry OCI image secret scanner</span>
+            <span>OCI image secret scanner</span>
           </span>
         </a>
         <nav class="site-nav" aria-label="Primary">
           <a class="nav-link" data-nav="docs" href="./">Docs</a>
-          <a class="nav-link" data-nav="demo" href="demo/">Try It Out</a>
+          <a class="nav-link" data-nav="demo" href="demo/">Demo</a>
           <a class="nav-link" href="https://github.com/brumbelow/layerleak">GitHub</a>
         </nav>
       </header>
 
-      <section class="hero" data-reveal>
-        <article class="hero-card hero-copy">
-          <span class="eyebrow"></span>
-          <h1>Your guide to the scanner and command line.</h1>
-          <p>
-            This site mirrors the current repository layout, additionally including an in-browser demo.
-          </p>
-        </article>
-        <aside class="feature-panel" data-reveal>
-          <span class="site-kicker">Quick links</span>
-          <div class="card"><h3><a href="#install">Install</a></h3><p>Build from source with Go 1.25.7+.</p></div>
-          <div class="card"><h3><a href="#postgres">Postgres</a></h3><p>Manual migrations and current-state persistence.</p></div>
-          <div class="card"><h3><a href="#api">HTTP API</a></h3><p>JSON endpoints backed by a local Postgres instance.</p></div>
-        </aside>
-      </section>
-
-      <div class="docs-shell">
-        <aside class="docs-nav" data-reveal>
-          <strong>Contents</strong>
-          <a href="#install">Install and build</a>
-          <a href="#env">Environment</a>
-          <a href="#results">Result behavior</a>
-          <a href="#postgres">Postgres persistence</a>
-          <a href="#cli">CLI usage</a>
-          <a href="#api">HTTP API</a>
-          <a href="#demo">Browser demo</a>
-        </aside>
-
-        <div class="docs-content">
-          <section class="doc-block" id="install" data-reveal>
-            <h2>Install and build</h2>
-            <p>layerleak currently targets Go 1.25.7+ and builds directly from source.</p>
-            <pre><code>go install github.com/brumbelow/layerleak@latest
-layerleak --help</code></pre>
-            <p>Optional local configuration still uses a plain environment file:</p>
-            <pre><code>cp .env.example .env</code></pre>
-          </section>
-
-          <section class="doc-block" id="env" data-reveal>
-            <h2>Environment</h2>
+      <main>
+        <section class="docs-hero" data-reveal>
+          <div class="docs-hero-copy">
+            <span class="site-kicker">Operator notes</span>
+            <h1>Scan public OCI images without unpacking trust.</h1>
             <p>
-              The scanner keeps its runtime surface small: registry endpoints, output location,
-              HTTP timeout, per-file and per-layer caps, repository-wide caps, and optional Postgres
-              persistence. Defaults are applied when a variable is unset.
+              layerleak reads registry manifests, config metadata, history, and filesystem layers
+              directly. It is read-only, daemonless, and built to keep actionable findings separate
+              from test fixtures and examples.
             </p>
-            <pre><code>export LAYERLEAK_FINDINGS_DIR=findings
-export LAYERLEAK_API_ADDR=127.0.0.1:8080
-export LAYERLEAK_PERSIST_RAW_SECRETS=0
-export LAYERLEAK_TAG_PAGE_SIZE=100
-export LAYERLEAK_HTTP_TIMEOUT=30s
-export LAYERLEAK_MAX_FILE_BYTES=1048576
-export LAYERLEAK_MAX_LAYER_BYTES=536870912
-export LAYERLEAK_MAX_LAYER_ENTRIES=50000
-export LAYERLEAK_MAX_MANIFEST_BYTES=0
-export LAYERLEAK_MAX_CONFIG_BYTES=0
-export LAYERLEAK_MAX_TAG_RESPONSE_BYTES=8388608
-export LAYERLEAK_MAX_REPOSITORY_TAGS=0
-export LAYERLEAK_MAX_REPOSITORY_TARGETS=0
-export LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS=2
-export LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?sslmode=disable</code></pre>
-            <p>
-              <code>LAYERLEAK_HTTP_TIMEOUT</code> applies to every registry HTTP call (manifest fetches,
-              blob downloads, tag pages, auth tokens) and accepts any Go duration value.
-              <code>LAYERLEAK_MAX_FILE_BYTES</code> caps decompressed bytes per file inside a layer;
-              files larger than this are classified as oversize and skipped.
-              The size and repository caps suffixed <code>_BYTES</code>, <code>_ENTRIES</code>,
-              <code>_TAGS</code>, and <code>_TARGETS</code> are disabled when set to <code>0</code>.
-              If enabled and exceeded, the scan fails closed but still writes the partial results
-              produced before the failure.
-            </p>
-          </section>
-
-          <section class="doc-block" id="results" data-reveal>
-            <h2>Result behavior</h2>
-            <p>
-              Actionable findings drive the CLI exit code and stay visible in <code>findings</code>.
-              Likely test, example, or demo placeholders are retained as suppressed findings with
-              <code>disposition</code>, <code>disposition_reason</code>, and <code>line_number</code>
-              metadata for triage. Suppressed findings do not count toward
-              <code>total_findings</code>.
-            </p>
-            <p>
-              Saved findings files and Postgres persistence default to redacted previews
-              (<code>redacted_value</code>, redacted <code>context_snippet</code>). Raw finding values
-              and raw snippets are written only when <code>LAYERLEAK_PERSIST_RAW_SECRETS=1</code> is
-              set explicitly. The <code>scan_runs.result_json</code> snapshot stays redacted in either
-              mode. If a configured operational limit trips, layerleak still writes the partial
-              results produced before the failure and exits with status <code>1</code>.
-            </p>
-            <div class="callout">
-              <strong>Secret-safety note</strong>
-              <p>
-                Persistence stores redacted previews by default. Raw <code>findings.value</code> and
-                <code>finding_occurrences.raw_snippet</code> stay empty unless
-                <code>LAYERLEAK_PERSIST_RAW_SECRETS=1</code>. Use a dedicated database or schema for
-                layerleak; for the safest purge path, drop the dedicated database or schema rather
-                than trying to surgically delete individual rows.
-              </p>
+            <div class="button-row">
+              <a class="button-primary" href="#quickstart">Install</a>
+              <a class="button-secondary" href="demo/">Open demo</a>
             </div>
-          </section>
+          </div>
 
-          <section class="doc-block" id="postgres" data-reveal>
-            <h2>Postgres persistence</h2>
-            <p>
-              Migrations are manual by design. The scanner does not auto-create or auto-upgrade the
-              schema. Layerleak requires PostgreSQL server <code>&gt;= 16.13</code>.
-            </p>
-            <pre><code>psql "$LAYERLEAK_DATABASE_URL" -f migrations/0001_initial.up.sql
+          <div class="layer-map" role="img" aria-label="layerleak scan flow">
+            <div class="layer-node registry">
+              <span>registry</span>
+              <strong>manifest + config</strong>
+            </div>
+            <div class="layer-rail" aria-hidden="true"></div>
+            <div class="layer-stack" aria-hidden="true">
+              <span style="--i: 0">layer sha256:8b9</span>
+              <span style="--i: 1">whiteouts</span>
+              <span style="--i: 2">history</span>
+              <span style="--i: 3">env + labels</span>
+            </div>
+            <div class="layer-node findings">
+              <span>result</span>
+              <strong>redacted JSON + optional Postgres</strong>
+            </div>
+          </div>
+        </section>
+
+        <section class="docs-status-strip" aria-label="Project facts" data-reveal>
+          <div>
+            <span>Install path</span>
+            <strong>github.com/brumbelow/layerleak@latest</strong>
+          </div>
+          <div>
+            <span>Runtime</span>
+            <strong>Go 1.25.7+</strong>
+          </div>
+          <div>
+            <span>Persistence</span>
+            <strong>PostgreSQL 16.13+</strong>
+          </div>
+          <div>
+            <span>Default exposure</span>
+            <strong>redacted findings</strong>
+          </div>
+        </section>
+
+        <div class="docs-shell">
+          <aside class="docs-nav" data-reveal>
+            <strong>Contents</strong>
+            <a href="#quickstart">Quickstart</a>
+            <a href="#scan-model">Scan model</a>
+            <a href="#configuration">Configuration</a>
+            <a href="#results">Results</a>
+            <a href="#postgres">Postgres</a>
+            <a href="#api">HTTP API</a>
+            <a href="#demo">Demo</a>
+          </aside>
+
+          <div class="docs-content">
+            <section class="doc-block" id="quickstart" data-reveal>
+              <div class="doc-heading">
+                <span>01</span>
+                <h2>Quickstart</h2>
+              </div>
+              <p>
+                The module root is the supported CLI entrypoint. Build or install from there, then
+                scan a public image reference.
+              </p>
+              <pre><code>go install github.com/brumbelow/layerleak@latest
+layerleak --help
+layerleak scan library/nginx:latest --format json</code></pre>
+              <p>
+                Source builds follow the same path:
+              </p>
+              <pre><code>git clone https://github.com/brumbelow/layerleak.git
+cd layerleak
+go build -o layerleak .
+./layerleak scan alpine:latest --platform linux/amd64</code></pre>
+            </section>
+
+            <section class="doc-block" id="scan-model" data-reveal>
+              <div class="doc-heading">
+                <span>02</span>
+                <h2>Scan model</h2>
+              </div>
+              <p>
+                layerleak supports public images on OCI-compatible registries including Docker Hub,
+                GHCR, Quay, GCR, MCR, Amazon ECR Public, and self-hosted registries. It does not
+                require a local Docker daemon and does not verify discovered secrets.
+              </p>
+              <div class="docs-grid">
+                <article>
+                  <h3>Single image</h3>
+                  <p>Use a tag or digest when the target scope should stay narrow.</p>
+                  <pre><code>layerleak scan mongo:latest
+layerleak scan repo/app@sha256:...</code></pre>
+                </article>
+                <article>
+                  <h3>Repository sweep</h3>
+                  <p>Bare repository names enumerate public tags, resolve digests, and group duplicates.</p>
+                  <pre><code>layerleak scan mongo
+layerleak scan quay.io/prometheus/busybox</code></pre>
+                </article>
+              </div>
+              <p>
+                Multi-arch indexes can be narrowed with <code>--platform os/arch[/variant]</code>.
+                Attestation and provenance manifests are skipped instead of counted as platform
+                scan failures.
+              </p>
+            </section>
+
+            <section class="doc-block" id="configuration" data-reveal>
+              <div class="doc-heading">
+                <span>03</span>
+                <h2>Configuration</h2>
+              </div>
+              <p>
+                Defaults live in <code>.env.example</code> and in the Go config loader. Limits fail
+                closed when exceeded, while preserving any partial results produced before the error.
+              </p>
+              <pre><code>LAYERLEAK_LOG_LEVEL=info
+LAYERLEAK_FINDINGS_DIR=findings
+LAYERLEAK_API_ADDR=127.0.0.1:8080
+LAYERLEAK_PERSIST_RAW_SECRETS=0
+LAYERLEAK_TAG_PAGE_SIZE=100
+LAYERLEAK_HTTP_TIMEOUT=30s
+LAYERLEAK_MAX_FILE_BYTES=1048576
+LAYERLEAK_MAX_LAYER_BYTES=536870912
+LAYERLEAK_MAX_LAYER_ENTRIES=50000
+LAYERLEAK_MAX_MANIFEST_BYTES=0
+LAYERLEAK_MAX_CONFIG_BYTES=0
+LAYERLEAK_MAX_TAG_RESPONSE_BYTES=8388608
+LAYERLEAK_MAX_REPOSITORY_TAGS=0
+LAYERLEAK_MAX_REPOSITORY_TARGETS=0
+LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS=2
+LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?sslmode=disable</code></pre>
+              <p>
+                Positive <code>MAX_*</code> values enable caps. A value of <code>0</code> disables
+                caps for the non-negative limit settings. <code>LAYERLEAK_HTTP_TIMEOUT</code> uses
+                Go duration syntax.
+              </p>
+            </section>
+
+            <section class="doc-block" id="results" data-reveal>
+              <div class="doc-heading">
+                <span>04</span>
+                <h2>Results</h2>
+              </div>
+              <p>
+                Actionable findings drive non-zero scan status and remain in <code>findings</code>.
+                Likely test, example, and demo placeholders are preserved as suppressed findings
+                with disposition metadata, but do not count toward <code>total_findings</code>.
+              </p>
+              <div class="result-schema">
+                <span>detector_name</span>
+                <span>source_type</span>
+                <span>manifest_digest</span>
+                <span>platform</span>
+                <span>line_number</span>
+                <span>redacted_value</span>
+                <span>fingerprint</span>
+                <span>present_in_final_image</span>
+              </div>
+              <p>
+                Saved files and Postgres writes default to redacted values and redacted context
+                snippets. Raw secret values and raw snippets are written only when
+                <code>LAYERLEAK_PERSIST_RAW_SECRETS=1</code>. API responses stay redacted even if a
+                writer persisted raw values.
+              </p>
+            </section>
+
+            <section class="doc-block" id="postgres" data-reveal>
+              <div class="doc-heading">
+                <span>05</span>
+                <h2>Postgres persistence</h2>
+              </div>
+              <p>
+                Migrations are manual on purpose. The scanner does not create or upgrade schema at
+                runtime. Use PostgreSQL server <code>&gt;= 16.13</code>.
+              </p>
+              <pre><code>psql "$LAYERLEAK_DATABASE_URL" -f migrations/0001_initial.up.sql
 psql "$LAYERLEAK_DATABASE_URL" -f migrations/0002_finding_occurrence_metadata.up.sql
 psql "$LAYERLEAK_DATABASE_URL" -f migrations/0003_scan_runs.up.sql</code></pre>
-            <p>
-              Or apply migrations using the container helper:
-            </p>
-            <pre><code>docker run --rm \
+              <p>
+                The container image includes a rerunnable helper:
+              </p>
+              <pre><code>docker run --rm \
   -e LAYERLEAK_DATABASE_URL="$LAYERLEAK_DATABASE_URL" \
   ghcr.io/brumbelow/layerleak:latest \
   layerleak-migrate-up</code></pre>
-            <p>
-              <code>layerleak-migrate-up</code> is safe to rerun when migrations are already
-              applied; if it detects a partial migration state, it exits non-zero and asks for
-              manual intervention. The schema keeps current deduplicated state with
-              <code>first_seen_at</code> / <code>last_seen_at</code> across repositories, tags,
-              manifests, findings, and occurrences, plus an append-only history in the
-              <code>scan_runs</code> table that stores a redacted snapshot of each scan result.
-            </p>
-          </section>
+              <p>
+                Current state is deduplicated by manifest digest and fingerprint. Append-only scan
+                history is stored in <code>scan_runs</code> as a redacted result snapshot.
+              </p>
+            </section>
 
-          <section class="doc-block" id="cli" data-reveal>
-            <h2>CLI usage</h2>
-            <p>
-              The primary command surface is still the scanner CLI. Image references can target any
-              public OCI-compliant registry — Docker Hub, GHCR, Quay, GCR, MCR, Amazon ECR Public, or
-              a self-hosted registry — without a Docker daemon.
-            </p>
-            <pre><code>./layerleak --help
-./layerleak scan --help
-
-./layerleak scan ubuntu
-./layerleak scan library/nginx:latest --format json
-./layerleak scan alpine:latest --platform linux/amd64
-./layerleak scan mongo
-./layerleak scan ghcr.io/homebrew/core/hello:latest
-./layerleak scan quay.io/prometheus/busybox:latest
-./layerleak scan gcr.io/distroless/static:nonroot
-./layerleak scan public.ecr.aws/docker/library/alpine:3.20
-./layerleak scan mcr.microsoft.com/hello-world:latest</code></pre>
-            <p>
-              Bare repository names enumerate public tags, resolve each tag to a digest, and group
-              duplicates so the same manifest is only scanned once. If you only want a single image,
-              use an explicit tag (<code>repo:tag</code>) or digest (<code>repo@sha256:...</code>).
-              Ctrl-C cancels the in-flight scan cleanly via context cancellation.
-            </p>
-          </section>
-
-          <section class="doc-block" id="api" data-reveal>
-            <h2>HTTP API</h2>
-            <p>
-              The API is a separate Go binary under <code>cmd/api</code>. It requires
-              <code>LAYERLEAK_DATABASE_URL</code>, serves JSON only, and shuts down gracefully on
-              <code>SIGINT</code> / <code>SIGTERM</code>.
-            </p>
-            <pre><code>go run ./cmd/api</code></pre>
-            <p>Current endpoints:</p>
-            <pre><code>POST /api/v1/scans
+            <section class="doc-block" id="api" data-reveal>
+              <div class="doc-heading">
+                <span>06</span>
+                <h2>HTTP API</h2>
+              </div>
+              <p>
+                The API binary under <code>cmd/api</code> is JSON-only and Postgres-backed. It
+                requires <code>LAYERLEAK_DATABASE_URL</code>; it does not serve from local findings
+                files.
+              </p>
+              <pre><code>go run ./cmd/api</code></pre>
+              <pre><code>GET  /health
+POST /api/v1/scans
 GET  /api/v1/scans/{id}
 GET  /api/v1/repositories
 GET  /api/v1/repositories/{repository}/scans
 GET  /api/v1/repositories/{repository}/findings
 GET  /api/v1/findings/{id}</code></pre>
-            <p>
-              <code>POST /api/v1/scans</code> stays synchronous and returns <code>scan_run_id</code>
-              whenever Postgres persistence is enabled.
-              <code>GET /api/v1/scans/{id}</code> returns the persisted run metadata plus the stored
-              redacted result snapshot.
-              <code>GET /api/v1/repositories/{repository}/scans</code> and
-              <code>.../findings</code> accept an optional <code>?registry=</code> query parameter
-              (for example <code>?registry=ghcr.io</code>); when omitted the registry defaults to
-              <code>docker.io</code>. Use it to fetch persisted scans for repositories on GHCR, Quay,
-              GCR, MCR, Amazon ECR Public, or any self-hosted registry.
-            </p>
-            <p>
-              All API responses mirror the redacted CLI/API view. They never expose raw secret
-              values or raw snippets from Postgres, even when
-              <code>LAYERLEAK_PERSIST_RAW_SECRETS=1</code> is set on the writer side. The API does
-              not include authentication; for org deployments, keep it on a private network and
-              front it with your own authn/authz gateway.
-            </p>
-          </section>
-
-          <section class="doc-block" id="demo" data-reveal>
-            <h2>Browser demo</h2>
-            <p>
-              The GitHub Pages demo is intentionally simulated. It replays a fixed scan command and
-              then shows a fake local Postgres snapshot that matches the storage model conceptually.
-            </p>
-            <pre><code>layerleak scan vulnerableHost:latest --platform linux/amd64</code></pre>
-            <p>
-              The transcript, findings file path, and database rows are all synthetic and versioned
-              in-repo as static fixture data.
-            </p>
-            <section>
-              <h1></h1>
+              <p>
+                <code>POST /api/v1/scans</code> accepts <code>reference</code> and optional
+                <code>platform</code>. Repository scan and finding list endpoints support
+                <code>?registry=</code>, plus pagination where applicable. The API has no built-in
+                auth layer; deploy it behind private network controls or an auth gateway.
+              </p>
             </section>
-            <p><a class="button-primary" href="demo/">Open the simulated demo</a></p>
-          </section>
+
+            <section class="doc-block" id="demo" data-reveal>
+              <div class="doc-heading">
+                <span>07</span>
+                <h2>Browser demo</h2>
+              </div>
+              <p>
+                The Pages demo is static and simulated. It replays a fixed transcript and renders a
+                synthetic Postgres-style snapshot from versioned fixture data in the repository.
+              </p>
+              <pre><code>layerleak scan vulnerableHost:latest --platform linux/amd64</code></pre>
+              <p><a class="button-primary" href="demo/">Open the simulated demo</a></p>
+            </section>
+          </div>
         </div>
-      </div>
+      </main>
 
       <footer class="site-footer">
         <span>layerleak documentation</span>


### PR DESCRIPTION
## Summary
- refresh the GitHub Pages docs page around the current install, scan, configuration, persistence, and API workflow
- replace the generic docs hero with a more focused operator-style layout and layer scan visual
- tighten responsive styles for the docs page

## Validation
- `npx --yes html-validate@latest web/docs/index.html`
- `git diff --check`
- Pages artifact file check matching `.github/workflows/pages.yml`

## Notes
- `go test -short ./...` was not run because Go is not installed in this environment.
- Browser screenshot validation was attempted with Playwright, but Chromium could not start because the host is missing `libatk-1.0.so.0`.
