### PR TITLE
docs: refresh docs page

### DIFF
--- a/web/assets/site.js
+++ b/web/assets/site.js
@@ -14,10 +14,12 @@
   }
 
   const reveals = document.querySelectorAll("[data-reveal]");
+  const show = (element) => {
+    element.classList.add("is-visible");
+  };
+
   if (!("IntersectionObserver" in window)) {
-    reveals.forEach((element) => {
-      element.classList.add("is-visible");
-    });
+    reveals.forEach(show);
     return;
   }
 
@@ -25,15 +27,21 @@
     (entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          entry.target.classList.add("is-visible");
+          show(entry.target);
           observer.unobserve(entry.target);
         }
       });
     },
-    { threshold: 0.18 }
+    { threshold: 0.18, rootMargin: "0px 0px -8% 0px" }
   );
 
   reveals.forEach((element) => {
+    const rect = element.getBoundingClientRect();
+    if (rect.top < window.innerHeight && rect.bottom > 0) {
+      show(element);
+      return;
+    }
+
     observer.observe(element);
   });
 })();

--- a/web/assets/styles.css
+++ b/web/assets/styles.css
@@ -5,12 +5,16 @@
   --paper-strong: #ffffff;
   --ink: #17202a;
   --ink-soft: #526071;
+  --ink-muted: #6f7d8d;
   --line: rgba(23, 32, 42, 0.14);
+  --line-strong: rgba(23, 32, 42, 0.22);
   --accent: #b84625;
   --accent-deep: #762c18;
   --signal: #0b6f63;
   --signal-soft: rgba(11, 111, 99, 0.12);
   --warn: #a65a0a;
+  --warn-soft: rgba(166, 90, 10, 0.12);
+  --focus: #0b6f63;
   --shadow: 0 18px 44px rgba(23, 32, 42, 0.1);
   --radius-lg: 8px;
   --radius-md: 8px;
@@ -44,9 +48,40 @@ a {
   color: inherit;
 }
 
+a:focus-visible,
+button:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.skip-link {
+  position: absolute;
+  top: -3rem;
+  left: 1rem;
+  padding: 0.55rem 0.9rem;
+  background: var(--ink);
+  color: #fff8ef;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+  z-index: 100;
+  transition: top 160ms ease;
+}
+
+.skip-link:focus-visible {
+  top: 0.75rem;
+}
+
 img {
   max-width: 100%;
   display: block;
+}
+
+.muted {
+  color: var(--ink-muted);
+  font-size: 0.92rem;
 }
 
 code,
@@ -380,8 +415,8 @@ pre,
 
 .docs-shell {
   display: grid;
-  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
-  gap: 1.25rem;
+  grid-template-columns: minmax(210px, 260px) minmax(0, 1fr);
+  gap: 1.5rem;
   margin: 1.75rem auto 3rem;
 }
 
@@ -389,54 +424,52 @@ pre,
   position: sticky;
   top: 1rem;
   align-self: start;
-  padding: 1.2rem;
+  padding: 1.1rem 1.2rem;
   border-radius: var(--radius-lg);
   background: rgba(255, 250, 241, 0.74);
   border: 1px solid rgba(24, 34, 45, 0.08);
   box-shadow: var(--shadow);
 }
 
-.docs-nav a {
-  display: block;
-  padding: 0.45rem 0;
-  text-decoration: none;
-  color: var(--ink-soft);
-}
-
-.docs-nav a:hover,
-.docs-nav a:focus-visible {
-  color: var(--accent-deep);
-}
-
 .docs-content {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .doc-block {
   padding: 1.55rem;
+  scroll-margin-top: 1.25rem;
 }
 
 .doc-block pre,
 .terminal-screen {
   overflow: auto;
   border-radius: var(--radius-md);
-  background: #161a1f;
+  background: #14181d;
   color: #d7e4f2;
-  padding: 1.15rem;
-  line-height: 1.45;
-  font-size: 0.9rem;
+  padding: 1.05rem 1.15rem;
+  line-height: 1.55;
+  font-size: 0.88rem;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.doc-block pre code {
+  color: inherit;
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
 }
 
 .doc-block code:not(pre code),
 .command-chip {
   display: inline-block;
-  padding: 0.18rem 0.45rem;
-  border-radius: 999px;
-  background: rgba(24, 34, 45, 0.06);
+  padding: 0.14rem 0.42rem;
+  border-radius: 4px;
+  background: rgba(24, 34, 45, 0.07);
   color: var(--accent-deep);
-  font-size: 0.92em;
+  font-size: 0.88em;
+  border: 1px solid rgba(24, 34, 45, 0.05);
 }
 
 .simulation-banner {
@@ -608,14 +641,15 @@ pre,
 
 .docs-page .site-header {
   border-bottom: 1px solid var(--line);
+  margin-bottom: 0.6rem;
 }
 
 .docs-hero {
   width: min(calc(100% - 2rem), var(--content));
-  margin: 3rem auto 1.2rem;
+  margin: 2.4rem auto 1.4rem;
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 0.8fr);
-  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.75fr);
+  gap: 2.2rem;
   align-items: center;
 }
 
@@ -625,29 +659,31 @@ pre,
 }
 
 .docs-hero h1 {
-  max-width: 12ch;
+  max-width: 16ch;
   margin: 0;
-  font-size: clamp(3rem, 7vw, 6.8rem);
-  line-height: 0.92;
-  letter-spacing: 0;
+  font-size: clamp(2.4rem, 5.4vw, 4.4rem);
+  line-height: 1;
+  letter-spacing: -0.01em;
 }
 
 .docs-hero p {
-  max-width: 45rem;
+  max-width: 50rem;
   margin: 0;
   color: var(--ink-soft);
-  font-size: 1.08rem;
+  font-size: 1.05rem;
+  line-height: 1.55;
 }
 
 .layer-map {
-  min-height: 32rem;
+  min-height: 26rem;
   padding: 1rem;
   border: 1px solid var(--line);
+  border-radius: var(--radius-md);
   background:
-    linear-gradient(90deg, rgba(23, 32, 42, 0.07) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(23, 32, 42, 0.05) 1px, transparent 1px),
-    rgba(255, 255, 255, 0.72);
-  background-size: 24px 24px;
+    linear-gradient(90deg, rgba(23, 32, 42, 0.06) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(23, 32, 42, 0.04) 1px, transparent 1px),
+    rgba(255, 255, 255, 0.78);
+  background-size: 22px 22px;
   display: grid;
   grid-template-rows: auto 1fr auto;
   gap: 0.8rem;
@@ -709,12 +745,14 @@ pre,
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.72);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.78);
+  overflow: hidden;
 }
 
 .docs-status-strip div {
   min-width: 0;
-  padding: 1rem;
+  padding: 0.9rem 1rem;
   border-right: 1px solid var(--line);
 }
 
@@ -724,8 +762,11 @@ pre,
 
 .docs-status-strip strong {
   display: block;
-  margin-top: 0.35rem;
+  margin-top: 0.3rem;
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.92rem;
   overflow-wrap: anywhere;
+  color: var(--ink);
 }
 
 .docs-page .docs-shell {
@@ -734,57 +775,237 @@ pre,
 
 .docs-page .docs-nav,
 .docs-page .doc-block {
-  background: rgba(255, 255, 255, 0.78);
+  background: rgba(255, 255, 255, 0.82);
   border: 1px solid var(--line);
   box-shadow: none;
 }
 
 .docs-page .doc-block {
-  padding: 1.35rem;
+  padding: 1.6rem 1.6rem 1.4rem;
+}
+
+.docs-page .doc-block + .doc-block {
+  border-top: 0;
+}
+
+.docs-page .doc-block > * + * {
+  margin-top: 0.9rem;
+}
+
+.docs-page .doc-block pre {
+  margin: 0;
+}
+
+.docs-nav strong {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--signal);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  margin-bottom: 0.6rem;
+  padding-bottom: 0.55rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.docs-nav a {
+  display: block;
+  padding: 0.4rem 0.55rem;
+  margin: 0 -0.55rem;
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--ink-soft);
+  font-size: 0.94rem;
+  transition: color 140ms ease, background 140ms ease;
+}
+
+.docs-nav a:hover,
+.docs-nav a:focus-visible {
+  color: var(--accent-deep);
+  background: rgba(193, 79, 43, 0.07);
 }
 
 .doc-heading {
   display: flex;
   align-items: baseline;
-  gap: 0.75rem;
-  margin-bottom: 0.85rem;
+  gap: 0.85rem;
+  margin-bottom: 0.4rem;
+  padding-bottom: 0.65rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.doc-heading span {
+  flex-shrink: 0;
+  padding: 0.18rem 0.5rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background: rgba(24, 34, 45, 0.04);
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  color: var(--ink);
 }
 
 .doc-heading h2 {
   margin: 0;
+  font-size: clamp(1.45rem, 2.2vw, 1.85rem);
 }
 
 .docs-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
-  margin: 1rem 0;
+  margin: 0.9rem 0;
 }
 
 .docs-grid article {
   min-width: 0;
-  padding: 1rem;
+  padding: 1.1rem;
   border: 1px solid var(--line);
-  background: rgba(244, 245, 239, 0.7);
+  border-radius: var(--radius-md);
+  background: rgba(244, 245, 239, 0.75);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.docs-grid article > * {
+  margin: 0;
 }
 
 .docs-grid h3 {
   margin-top: 0;
 }
 
+.schema-heading {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--signal);
+  margin: 1rem 0 0.5rem;
+}
+
 .result-schema {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 1rem 0;
+  gap: 0.45rem;
+  margin: 0.4rem 0 0.6rem;
 }
 
 .result-schema span {
-  padding: 0.42rem 0.62rem;
-  border: 1px solid rgba(11, 111, 99, 0.2);
+  padding: 0.36rem 0.6rem;
+  border: 1px solid rgba(11, 111, 99, 0.22);
+  border-radius: 4px;
   background: var(--signal-soft);
   font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
   font-size: 0.82rem;
+  color: var(--ink);
+}
+
+.config-notes {
+  margin: 0.4rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.config-notes li {
+  position: relative;
+  padding: 0.55rem 0.85rem 0.55rem 1.5rem;
+  border-left: 3px solid var(--signal);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: rgba(11, 111, 99, 0.06);
+  color: var(--ink-soft);
+  font-size: 0.94rem;
+}
+
+.config-notes li::before {
+  content: "";
+  position: absolute;
+  left: 0.55rem;
+  top: 0.95rem;
+  width: 0.3rem;
+  height: 0.3rem;
+  border-radius: 50%;
+  background: var(--signal);
+}
+
+.config-notes strong {
+  color: var(--ink);
+}
+
+.api-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.api-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(244, 245, 239, 0.65);
+}
+
+.api-list code {
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.92rem;
+  color: var(--ink);
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  display: inline;
+}
+
+.verb {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.4rem;
+  padding: 0.18rem 0.55rem;
+  border-radius: 4px;
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.verb-get {
+  background: var(--signal-soft);
+  color: var(--signal);
+  border: 1px solid rgba(11, 111, 99, 0.25);
+}
+
+.verb-post {
+  background: rgba(193, 79, 43, 0.1);
+  color: var(--accent-deep);
+  border: 1px solid rgba(193, 79, 43, 0.25);
+}
+
+.docs-page .callout {
+  margin: 0.4rem 0 0;
+  padding: 0.95rem 1.1rem;
+  background: rgba(244, 245, 239, 0.85);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--signal);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  box-shadow: none;
+}
+
+.docs-page .callout.callout-warn {
+  border-left-color: var(--warn);
+  background: var(--warn-soft);
+}
+
+.docs-page .callout strong {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--ink);
 }
 
 .site-footer {
@@ -797,14 +1018,13 @@ pre,
 }
 
 [data-reveal] {
-  opacity: 0;
-  transform: translateY(18px);
-  transition: opacity 520ms ease, transform 520ms ease;
+  opacity: 1;
+  transform: none;
 }
 
 [data-reveal].is-visible {
   opacity: 1;
-  transform: translateY(0);
+  transform: none;
 }
 
 @media (max-width: 1024px) {
@@ -854,7 +1074,7 @@ pre,
   .doc-block,
   .callout,
   .stat-card {
-    border-radius: 20px;
+    border-radius: 14px;
   }
 
   .hero-card {
@@ -871,23 +1091,32 @@ pre,
 
   .docs-hero {
     margin-top: 1.7rem;
+    gap: 1.4rem;
   }
 
   .docs-hero h1 {
-    font-size: clamp(2.6rem, 15vw, 4.2rem);
+    font-size: clamp(2.1rem, 9vw, 3.4rem);
   }
 
   .layer-map {
-    min-height: 26rem;
+    min-height: auto;
+    grid-template-rows: auto auto auto;
+  }
+
+  .layer-rail {
+    display: none;
   }
 
   .layer-stack {
-    inset: 6.3rem 1rem 6.3rem;
+    position: static;
+    inset: auto;
+    margin: 0.2rem 0;
   }
 
   .layer-stack span {
     margin-left: 0;
     width: 100%;
+    box-shadow: 5px 5px 0 rgba(11, 111, 99, 0.08);
   }
 
   .docs-status-strip div,
@@ -898,6 +1127,19 @@ pre,
 
   .docs-status-strip div:last-child {
     border-bottom: 0;
+  }
+
+  .docs-page .doc-block {
+    padding: 1.25rem;
+  }
+
+  .doc-heading h2 {
+    font-size: 1.35rem;
+  }
+
+  .api-list li {
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
 
   .terminal-screen {
@@ -911,5 +1153,22 @@ pre,
   .site-footer {
     align-items: flex-start;
     flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  [data-reveal],
+  [data-reveal].is-visible,
+  .button-primary,
+  .button-secondary,
+  .tab-button,
+  .nav-link,
+  .skip-link {
+    transition: none;
+    transform: none;
   }
 }

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<meta name="h1-domain-verification" content="YEzunEmsGHbz4UhR6L4jVfgg6Aa3jyE1BqNzdrVRvtph1pkw">
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>layerleak Docs</title>
+    <title>layerleak docs</title>
     <meta
       name="description"
       content="Install, operate, and deploy layerleak, a daemonless OCI image secret scanner."
@@ -13,10 +12,11 @@
     <script defer src="../assets/site.js"></script>
   </head>
   <body data-page="docs">
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <div class="site-shell docs-page">
       <header class="site-header">
         <a class="brand-lockup" href="./">
-          <span class="brand-badge">LL</span>
+          <span class="brand-badge" aria-hidden="true">LL</span>
           <span class="brand-copy">
             <strong>layerleak</strong>
             <span>OCI image secret scanner</span>
@@ -29,44 +29,44 @@
         </nav>
       </header>
 
-      <main>
+      <main id="main-content">
         <section class="docs-hero" data-reveal>
           <div class="docs-hero-copy">
             <span class="site-kicker">Operator notes</span>
-            <h1>Scan public OCI images without unpacking trust.</h1>
+            <h1>Scan public OCI images without a daemon.</h1>
             <p>
-              layerleak reads registry manifests, config metadata, history, and filesystem layers
-              directly. It is read-only, daemonless, and built to keep actionable findings separate
-              from test fixtures and examples.
+              layerleak reads registry manifests, image config, build history, and decompressed
+              filesystem layers directly. It is read-only, runs as a single Go binary, and keeps
+              actionable findings separated from likely test fixtures and example placeholders.
             </p>
             <div class="button-row">
               <a class="button-primary" href="#quickstart">Install</a>
-              <a class="button-secondary" href="demo/">Open demo</a>
+              <a class="button-secondary" href="demo/">Open simulated demo</a>
             </div>
           </div>
 
-          <div class="layer-map" role="img" aria-label="layerleak scan flow">
+          <div class="layer-map" role="img" aria-label="layerleak scan flow: registry manifest and config feed layer extraction, then redacted JSON output and optional Postgres persistence">
             <div class="layer-node registry">
-              <span>registry</span>
-              <strong>manifest + config</strong>
+              <span>input</span>
+              <strong>registry manifest + config</strong>
             </div>
             <div class="layer-rail" aria-hidden="true"></div>
             <div class="layer-stack" aria-hidden="true">
-              <span style="--i: 0">layer sha256:8b9</span>
+              <span style="--i: 0">layer sha256:8b9…</span>
               <span style="--i: 1">whiteouts</span>
-              <span style="--i: 2">history</span>
+              <span style="--i: 2">image history</span>
               <span style="--i: 3">env + labels</span>
             </div>
             <div class="layer-node findings">
-              <span>result</span>
-              <strong>redacted JSON + optional Postgres</strong>
+              <span>output</span>
+              <strong>redacted JSON · optional Postgres</strong>
             </div>
           </div>
         </section>
 
         <section class="docs-status-strip" aria-label="Project facts" data-reveal>
           <div>
-            <span>Install path</span>
+            <span>Install</span>
             <strong>github.com/brumbelow/layerleak@latest</strong>
           </div>
           <div>
@@ -84,15 +84,16 @@
         </section>
 
         <div class="docs-shell">
-          <aside class="docs-nav" data-reveal>
-            <strong>Contents</strong>
-            <a href="#quickstart">Quickstart</a>
-            <a href="#scan-model">Scan model</a>
-            <a href="#configuration">Configuration</a>
-            <a href="#results">Results</a>
-            <a href="#postgres">Postgres</a>
-            <a href="#api">HTTP API</a>
-            <a href="#demo">Demo</a>
+          <aside class="docs-nav" data-reveal aria-label="Section">
+            <strong>On this page</strong>
+            <a href="#quickstart">01 · Quickstart</a>
+            <a href="#scan-model">02 · Scan model</a>
+            <a href="#configuration">03 · Configuration</a>
+            <a href="#results">04 · Results</a>
+            <a href="#postgres">05 · Postgres</a>
+            <a href="#api">06 · HTTP API</a>
+            <a href="#deploy">07 · Container &amp; Compose</a>
+            <a href="#demo">08 · Demo</a>
           </aside>
 
           <div class="docs-content">
@@ -102,19 +103,24 @@
                 <h2>Quickstart</h2>
               </div>
               <p>
-                The module root is the supported CLI entrypoint. Build or install from there, then
-                scan a public image reference.
+                The module root is the supported CLI entrypoint. Install or build from there, then
+                scan a public image reference. <code>GOBIN</code> or <code>GOPATH/bin</code> must be
+                on <code>PATH</code> after <code>go install</code>.
               </p>
               <pre><code>go install github.com/brumbelow/layerleak@latest
 layerleak --help
 layerleak scan library/nginx:latest --format json</code></pre>
               <p>
-                Source builds follow the same path:
+                Source builds use the same module:
               </p>
               <pre><code>git clone https://github.com/brumbelow/layerleak.git
 cd layerleak
 go build -o layerleak .
 ./layerleak scan alpine:latest --platform linux/amd64</code></pre>
+              <p class="muted">
+                To pin a published release, replace <code>@latest</code> with the
+                <code>v1.x.y</code> tag you want.
+              </p>
             </section>
 
             <section class="doc-block" id="scan-model" data-reveal>
@@ -136,15 +142,21 @@ layerleak scan repo/app@sha256:...</code></pre>
                 </article>
                 <article>
                   <h3>Repository sweep</h3>
-                  <p>Bare repository names enumerate public tags, resolve digests, and group duplicates.</p>
+                  <p>Bare repository names enumerate public tags, resolve each tag to a digest, and group duplicate digests.</p>
                   <pre><code>layerleak scan mongo
 layerleak scan quay.io/prometheus/busybox</code></pre>
                 </article>
               </div>
               <p>
-                Multi-arch indexes can be narrowed with <code>--platform os/arch[/variant]</code>.
-                Attestation and provenance manifests are skipped instead of counted as platform
-                scan failures.
+                Multi-arch indexes can be narrowed with
+                <code>--platform os/arch[/variant]</code>. Attestation and provenance manifests
+                (for example <code>application/vnd.in-toto+json</code>) are skipped instead of
+                counted as platform scan failures.
+              </p>
+              <p>
+                Detection uses native detectors for 60+ secret types, with TruffleHog defaults as a
+                fallback layer. Findings on paths that look like tests, fixtures, examples, specs,
+                or e2e suites are kept as suppressed findings rather than counted as actionable.
               </p>
             </section>
 
@@ -154,8 +166,9 @@ layerleak scan quay.io/prometheus/busybox</code></pre>
                 <h2>Configuration</h2>
               </div>
               <p>
-                Defaults live in <code>.env.example</code> and in the Go config loader. Limits fail
-                closed when exceeded, while preserving any partial results produced before the error.
+                Defaults live in <code>.env.example</code> and the Go config loader. Positive
+                <code>MAX_*</code> caps fail closed when exceeded, while preserving the partial
+                results produced before the failure.
               </p>
               <pre><code>LAYERLEAK_LOG_LEVEL=info
 LAYERLEAK_FINDINGS_DIR=findings
@@ -173,11 +186,31 @@ LAYERLEAK_MAX_REPOSITORY_TAGS=0
 LAYERLEAK_MAX_REPOSITORY_TARGETS=0
 LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS=2
 LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?sslmode=disable</code></pre>
-              <p>
-                Positive <code>MAX_*</code> values enable caps. A value of <code>0</code> disables
-                caps for the non-negative limit settings. <code>LAYERLEAK_HTTP_TIMEOUT</code> uses
-                Go duration syntax.
-              </p>
+              <ul class="config-notes">
+                <li>
+                  <strong>Limits.</strong> Settings with a non-negative semantic
+                  (<code>MAX_LAYER_BYTES</code>, <code>MAX_LAYER_ENTRIES</code>,
+                  <code>MAX_MANIFEST_BYTES</code>, <code>MAX_CONFIG_BYTES</code>,
+                  <code>MAX_TAG_RESPONSE_BYTES</code>, <code>MAX_REPOSITORY_TAGS</code>,
+                  <code>MAX_REPOSITORY_TARGETS</code>) accept <code>0</code> to disable the cap.
+                  <code>MAX_FILE_BYTES</code> must be greater than zero.
+                </li>
+                <li>
+                  <strong>Timeouts.</strong> <code>LAYERLEAK_HTTP_TIMEOUT</code> uses Go duration
+                  syntax (<code>30s</code>, <code>2m</code>, <code>1h</code>) and applies to every
+                  registry request: manifests, blobs, tag pages, and auth tokens.
+                </li>
+                <li>
+                  <strong>Registry overrides.</strong>
+                  <code>LAYERLEAK_REGISTRY_BASE_URL</code> and
+                  <code>LAYERLEAK_REGISTRY_AUTH_URL</code> are optional. Leave them unset unless
+                  forcing traffic through a proxy or alternate auth endpoint.
+                </li>
+                <li>
+                  <strong>API container.</strong> The published image defaults
+                  <code>LAYERLEAK_API_ADDR</code> to <code>0.0.0.0:8080</code>.
+                </li>
+              </ul>
             </section>
 
             <section class="doc-block" id="results" data-reveal>
@@ -186,19 +219,41 @@ LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?ssl
                 <h2>Results</h2>
               </div>
               <p>
-                Actionable findings drive non-zero scan status and remain in <code>findings</code>.
-                Likely test, example, and demo placeholders are preserved as suppressed findings
-                with disposition metadata, but do not count toward <code>total_findings</code>.
+                Actionable findings remain in <code>findings</code> and drive the non-zero scan
+                exit status. Likely test, example, fixture, and spec placeholders are emitted as
+                suppressed findings with disposition metadata, and do not count toward
+                <code>total_findings</code>.
               </p>
-              <div class="result-schema">
-                <span>detector_name</span>
-                <span>source_type</span>
-                <span>manifest_digest</span>
-                <span>platform</span>
-                <span>line_number</span>
-                <span>redacted_value</span>
-                <span>fingerprint</span>
-                <span>present_in_final_image</span>
+              <p>
+                A scan saves a JSON file under <code>LAYERLEAK_FINDINGS_DIR</code>. If unset, it
+                defaults to <code>findings/</code> beside the nearest <code>go.mod</code>, falling
+                back to the current working directory.
+              </p>
+              <h3 class="schema-heading">Per-occurrence fields</h3>
+              <div class="result-schema" role="list">
+                <span role="listitem">detector_name</span>
+                <span role="listitem">confidence</span>
+                <span role="listitem">disposition</span>
+                <span role="listitem">disposition_reason</span>
+                <span role="listitem">source_type</span>
+                <span role="listitem">platform</span>
+                <span role="listitem">file_path</span>
+                <span role="listitem">layer_digest</span>
+                <span role="listitem">line_number</span>
+                <span role="listitem">source_location</span>
+                <span role="listitem">context_snippet</span>
+                <span role="listitem">present_in_final_image</span>
+              </div>
+              <h3 class="schema-heading">Per-finding fields</h3>
+              <div class="result-schema" role="list">
+                <span role="listitem">manifest_digest</span>
+                <span role="listitem">fingerprint</span>
+                <span role="listitem">redacted_value</span>
+                <span role="listitem">occurrence_count</span>
+                <span role="listitem">actionable_occurrence_count</span>
+                <span role="listitem">suppressed_occurrence_count</span>
+                <span role="listitem">first_seen_at</span>
+                <span role="listitem">last_seen_at</span>
               </div>
               <p>
                 Saved files and Postgres writes default to redacted values and redacted context
@@ -221,16 +276,23 @@ LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?ssl
 psql "$LAYERLEAK_DATABASE_URL" -f migrations/0002_finding_occurrence_metadata.up.sql
 psql "$LAYERLEAK_DATABASE_URL" -f migrations/0003_scan_runs.up.sql</code></pre>
               <p>
-                The container image includes a rerunnable helper:
+                The published container image ships a rerunnable helper that enforces server
+                version <code>&gt;= 16.13</code> and exits non-zero on partial migration state:
               </p>
               <pre><code>docker run --rm \
   -e LAYERLEAK_DATABASE_URL="$LAYERLEAK_DATABASE_URL" \
   ghcr.io/brumbelow/layerleak:latest \
   layerleak-migrate-up</code></pre>
               <p>
-                Current state is deduplicated by manifest digest and fingerprint. Append-only scan
-                history is stored in <code>scan_runs</code> as a redacted result snapshot.
+                Current state is deduplicated by <code>(manifest_digest, fingerprint)</code>.
+                Append-only scan history lives in <code>scan_runs</code> as a redacted snapshot of
+                the public result JSON, regardless of <code>LAYERLEAK_PERSIST_RAW_SECRETS</code>.
               </p>
+              <div class="callout" role="note">
+                <strong>Safe purge</strong>
+                Use a dedicated database or schema for layerleak. To clear stored data, drop the
+                schema or database rather than deleting individual rows.
+              </div>
             </section>
 
             <section class="doc-block" id="api" data-reveal>
@@ -244,29 +306,72 @@ psql "$LAYERLEAK_DATABASE_URL" -f migrations/0003_scan_runs.up.sql</code></pre>
                 files.
               </p>
               <pre><code>go run ./cmd/api</code></pre>
-              <pre><code>GET  /health
-POST /api/v1/scans
-GET  /api/v1/scans/{id}
-GET  /api/v1/repositories
-GET  /api/v1/repositories/{repository}/scans
-GET  /api/v1/repositories/{repository}/findings
-GET  /api/v1/findings/{id}</code></pre>
+              <ul class="api-list">
+                <li><span class="verb verb-get">GET</span><code>/health</code></li>
+                <li><span class="verb verb-post">POST</span><code>/api/v1/scans</code></li>
+                <li><span class="verb verb-get">GET</span><code>/api/v1/scans/{id}</code></li>
+                <li><span class="verb verb-get">GET</span><code>/api/v1/repositories</code></li>
+                <li><span class="verb verb-get">GET</span><code>/api/v1/repositories/{repository}/scans</code></li>
+                <li><span class="verb verb-get">GET</span><code>/api/v1/repositories/{repository}/findings</code></li>
+                <li><span class="verb verb-get">GET</span><code>/api/v1/findings/{id}</code></li>
+              </ul>
               <p>
-                <code>POST /api/v1/scans</code> accepts <code>reference</code> and optional
-                <code>platform</code>. Repository scan and finding list endpoints support
-                <code>?registry=</code>, plus pagination where applicable. The API has no built-in
-                auth layer; deploy it behind private network controls or an auth gateway.
+                <code>POST /api/v1/scans</code> is synchronous and accepts a JSON body with
+                <code>reference</code> and optional <code>platform</code>. The response includes
+                <code>scan_run_id</code> when Postgres persistence is enabled, plus the same
+                redacted result schema produced by the CLI.
+              </p>
+              <p>
+                Repository scan and finding list endpoints accept an optional
+                <code>?registry=</code> query parameter (defaults to <code>docker.io</code>),
+                plus <code>?limit=</code> and <code>?offset=</code> pagination
+                (max <code>limit</code> is 200). Findings list also accepts
+                <code>?disposition=actionable|suppressed|all</code>.
+              </p>
+              <div class="callout callout-warn" role="note">
+                <strong>No built-in auth</strong>
+                The API does not include an authentication layer. Deploy it on a private network
+                and front it with your own authn/authz gateway or reverse proxy policy.
+              </div>
+            </section>
+
+            <section class="doc-block" id="deploy" data-reveal>
+              <div class="doc-heading">
+                <span>07</span>
+                <h2>Container &amp; Compose</h2>
+              </div>
+              <p>
+                The published image runs the API by default. It binds
+                <code>0.0.0.0:8080</code> and expects <code>LAYERLEAK_DATABASE_URL</code>.
+              </p>
+              <pre><code>docker pull ghcr.io/brumbelow/layerleak:latest
+docker run --rm \
+  -p 8080:8080 \
+  -e LAYERLEAK_DATABASE_URL='postgres://&lt;user&gt;:&lt;pass&gt;@&lt;host&gt;:5432/layerleak?sslmode=disable' \
+  ghcr.io/brumbelow/layerleak:latest</code></pre>
+              <p>
+                The repository ships a Compose stack in <code>docker-compose.yml</code> with
+                <code>db</code>, <code>migrate</code>, and <code>api</code> services. The
+                <code>db</code> service baseline is pinned to
+                <code>postgres:16.13-alpine</code>.
+              </p>
+              <pre><code>docker compose --profile manual run --rm migrate
+docker compose up -d api</code></pre>
+              <p>
+                In Dockge or Komodo, import the same Compose file and run the <code>migrate</code>
+                service once before enabling the long-running <code>api</code> service.
               </p>
             </section>
 
             <section class="doc-block" id="demo" data-reveal>
               <div class="doc-heading">
-                <span>07</span>
+                <span>08</span>
                 <h2>Browser demo</h2>
               </div>
               <p>
-                The Pages demo is static and simulated. It replays a fixed transcript and renders a
+                The Pages demo is fully static. It replays a fixed transcript and renders a
                 synthetic Postgres-style snapshot from versioned fixture data in the repository.
+                Nothing is sent to any registry or database.
               </p>
               <pre><code>layerleak scan vulnerableHost:latest --platform linux/amd64</code></pre>
               <p><a class="button-primary" href="demo/">Open the simulated demo</a></p>


### PR DESCRIPTION
## Summary
- Refresh the docs page for current CLI, API, configuration, persistence, and container behavior.
- Redesign the static docs layout for readability, navigation, accessibility, and mobile rendering.
- Remove the obsolete H1 domain verification meta tag.

## Testing
- `go test ./...`
- `node --check web/assets/site.js`
- `git diff --check`
- Static docs validation for anchors, assets, section IDs, API routes, and CSS balance
