### PR TITLE
feat: add release versioning and scan scope controls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,12 @@ jobs:
 
       - name: go test
         run: go test ./... -count=1
+
+      - name: install smoke
+        run: |
+          set -euo pipefail
+          install_bin="$(mktemp -d)"
+          GOBIN="${install_bin}" go install .
+          "${install_bin}/layerleak" --help
+          "${install_bin}/layerleak" scan --help
+          "${install_bin}/layerleak" --version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,9 @@ Use an explicit tag or digest when you want to limit scope.
 
 - The canonical user install path is `go install github.com/brumbelow/layerleak@latest`.
 - The module root must remain the installable CLI entrypoint.
-- For the current module path `github.com/brumbelow/layerleak`, publish only `v1.x.y` release tags.
-- Do not publish new `v2+` tags from the root module unless the module path first changes to `github.com/brumbelow/layerleak/vN`.
-- Before cutting a release tag, verify both `go test ./...` and `GOBIN=/tmp/layerleak-bin go install .` succeed.
+- For the current module path `github.com/brumbelow/layerleak`, publish only `v1.x.y` release tags. `v1.0.0` is already published; the next root-module release continues that sequence (for example, `v1.1.0`).
+- Do not publish new `v2+` tags from the root module unless the module path first changes to `github.com/brumbelow/layerleak/vN`. Historical `v2.x` GitHub Releases are not module-major releases and are not picked up by `go install @latest`.
+- Before cutting a release tag, verify `go test ./... -count=1`, `GOBIN=/tmp/layerleak-bin go install .`, and that `layerleak --help`, `layerleak scan --help`, and `layerleak --version` all run on the installed binary.
 
 ## Contribution Rules
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ go install github.com/brumbelow/layerleak@v1.0.0
 Replace `v1.0.0` with the published `v1.x.y` tag you want.
 Make sure your `GOBIN` or `GOPATH/bin` directory is on `PATH`.
 
+The module path is `github.com/brumbelow/layerleak`, so `go install @latest` resolves to the highest published `v1.x.y` tag. A `v2.x.y` module release would require the module path to change to `github.com/brumbelow/layerleak/v2`. Module-installed binaries report the resolved module version through `layerleak --version`; local checkout builds report the version Go embeds for the checkout, falling back to `dev` when no module version is available.
+
 Build from source:
 
 ```bash
@@ -228,7 +230,12 @@ Those saved findings files contain finding records with `redacted_value`, redact
 If `LAYERLEAK_PERSIST_RAW_SECRETS=1`, the saved findings files also include raw `value` and `raw_context_snippet`.
 If Postgres persistence is enabled, raw `findings.value` and `finding_occurrences.raw_snippet` stay empty unless `LAYERLEAK_PERSIST_RAW_SECRETS=1`.
 For multi-arch images, layerleak skips attestation and provenance manifests such as `application/vnd.in-toto+json` instead of counting them as failed platform scans.
-If you pass a bare repository name such as `mongo`, layerleak enumerates all public tags in that repository, resolves each tag to a digest, groups duplicate digests, and scans the distinct targets. If you want a single image only, pass an explicit tag or digest such as `mongo:latest` or `mongo@sha256:...`.
+
+Bare repository sweeps:
+
+- Passing a bare repository name such as `mongo` enumerates every public tag in that repository, resolves each tag to a digest, groups duplicate digests, and scans the distinct targets.
+- layerleak prints a warning on stderr before starting the sweep so the scope is obvious in CI logs and automation output.
+- If you want a single image only, pass an explicit tag or digest such as `mongo:latest` or `mongo@sha256:...`.
 
 Command syntax:
 
@@ -236,6 +243,14 @@ Command syntax:
 layerleak [command]
 layerleak scan <image-ref> [flags]
 ```
+
+Scope flags for repository sweeps (each overrides the matching environment variable for a single command):
+
+| Flag | Purpose |
+| --- | --- |
+| `--tag-page-size` | Registry tag-list page size for repository sweeps. Must be greater than zero. Overrides `LAYERLEAK_TAG_PAGE_SIZE`. |
+| `--max-repository-tags` | Maximum tags enumerated per repository sweep. `0` disables the limit. Overrides `LAYERLEAK_MAX_REPOSITORY_TAGS`. |
+| `--max-repository-targets` | Maximum distinct targets resolved per repository sweep. `0` disables the limit. Overrides `LAYERLEAK_MAX_REPOSITORY_TARGETS`. |
 
 ## HTTP API
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,14 @@
 
 - The canonical install path is `go install github.com/brumbelow/layerleak@latest`.
 - The current module path is `github.com/brumbelow/layerleak`, so release tags for this module must stay on `v1.x.y`.
-- The next stable root-module release should be `v1.0.0`.
-- Do not publish new `v2+` tags from this module path. A true v2 release requires a module path change to `github.com/brumbelow/layerleak/v2`.
+- `v1.0.0` is already published. The next root-module release continues the `v1.x.y` sequence, for example `v1.1.0` for the next feature release or `v1.0.1` for a patch.
+- Do not publish new `v2+` tags from this module path. Historical `v2.x` GitHub Releases are not valid module-major releases for `go install github.com/brumbelow/layerleak@latest` and are not selectable by the Go module proxy. A true v2 release requires changing the module path to `github.com/brumbelow/layerleak/v2`.
+
+## Choosing the Next Tag
+
+- Bump the minor version (`v1.N+1.0`) for additive, backward-compatible changes to the CLI, API surface, configuration schema, or persistence schema.
+- Bump the patch version (`v1.N.M+1`) for bug fixes and documentation-only changes that do not change behavior.
+- Do not reuse a tag that has already been pushed.
 
 ## Release Checklist
 
@@ -13,23 +19,35 @@
 2. Verify local quality checks:
 
 ```bash
-go test ./...
+go test ./... -count=1
 GOBIN=/tmp/layerleak-bin GOCACHE=/tmp/layerleak-gocache go install .
 /tmp/layerleak-bin/layerleak --help
+/tmp/layerleak-bin/layerleak scan --help
+/tmp/layerleak-bin/layerleak --version
 ```
 
 3. Create the next root-compatible tag, for example:
 
 ```bash
-git tag v1.0.0
-git push origin v1.0.0
+git tag v1.1.0
+git push origin v1.1.0
 ```
 
-4. After the tag is pushed, verify the published install path from a clean environment:
+4. After the tag is pushed, verify the published install path from a clean module cache:
 
 ```bash
+GOBIN=/tmp/layerleak-release-check/bin \
+GOCACHE=/tmp/layerleak-release-check/cache \
+GOMODCACHE=/tmp/layerleak-release-check/mod \
 go install github.com/brumbelow/layerleak@latest
-layerleak --help
+/tmp/layerleak-release-check/bin/layerleak --help
+/tmp/layerleak-release-check/bin/layerleak --version
 ```
 
-5. If install behavior changed, update `README.md` and `CONTRIBUTING.md` in the same release train.
+5. `layerleak --version` for a module-installed binary should report the published tag via Go build info. Local checkout builds report the version Go embeds for the checkout, falling back to `dev` when no module version is available.
+
+6. If install behavior changed, update `README.md` and `CONTRIBUTING.md` in the same release train.
+
+## GitHub Releases
+
+The Go module proxy resolves `@latest` by reading repository tags, not by reading the GitHub Releases "Latest" designation. Treat the GitHub Releases UI as documentation only. The authoritative install target for users is the highest semver-compatible tag on the root module, which must be a `v1.x.y` tag while the module path is `github.com/brumbelow/layerleak`.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,7 +39,7 @@ func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "layerleak",
 		Short:         "Scan public OCI images for likely secrets",
-		Version:       Version,
+		Version:       effectiveVersion(),
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -15,9 +15,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const repositorySweepWarning = "warning: bare repository reference; layerleak enumerates every public tag in the repository. Pass a tag or digest (e.g. <repo>:tag) to scan a single image."
+
 func newScanCmd() *cobra.Command {
 	var platform string
 	var format string
+	var tagPageSize int
+	var maxRepositoryTags int
+	var maxRepositoryTargets int
 
 	cmd := &cobra.Command{
 		Use:   "scan <image-ref>",
@@ -26,6 +31,10 @@ func newScanCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
+				return err
+			}
+
+			if err := applyScanScopeFlags(cmd, &cfg, tagPageSize, maxRepositoryTags, maxRepositoryTargets); err != nil {
 				return err
 			}
 
@@ -44,11 +53,21 @@ func newScanCmd() *cobra.Command {
 				ctx = context.Background()
 			}
 
+			if ref.IsRepositoryOnly() {
+				if _, err := fmt.Fprintln(cmd.ErrOrStderr(), repositorySweepWarning); err != nil {
+					return err
+				}
+			}
+
 			progress := newProgressRenderer(cmd.ErrOrStderr())
+			startingMessage := "Preparing scan"
+			if ref.IsRepositoryOnly() {
+				startingMessage = "Preparing repository sweep across every public tag"
+			}
 			if err := progress.Start(progressSnapshot{
 				repository: ref.Repository,
 				phase:      "Starting",
-				message:    "Preparing scan",
+				message:    startingMessage,
 			}); err != nil {
 				return err
 			}
@@ -204,8 +223,33 @@ func newScanCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&platform, "platform", "", "Scan only the specified platform in os/arch[/variant] format")
 	cmd.Flags().StringVar(&format, "format", "summary", "Output format: summary or json")
+	cmd.Flags().IntVar(&tagPageSize, "tag-page-size", 0, "Registry tag-list page size for repository sweeps. Overrides LAYERLEAK_TAG_PAGE_SIZE. Must be greater than zero when set.")
+	cmd.Flags().IntVar(&maxRepositoryTags, "max-repository-tags", 0, "Maximum tags enumerated per repository sweep. Overrides LAYERLEAK_MAX_REPOSITORY_TAGS. Set to 0 to disable the limit; negative values are rejected.")
+	cmd.Flags().IntVar(&maxRepositoryTargets, "max-repository-targets", 0, "Maximum distinct targets resolved per repository sweep. Overrides LAYERLEAK_MAX_REPOSITORY_TARGETS. Set to 0 to disable the limit; negative values are rejected.")
 
 	return cmd
+}
+
+func applyScanScopeFlags(cmd *cobra.Command, cfg *config.Config, tagPageSize, maxRepositoryTags, maxRepositoryTargets int) error {
+	if cmd.Flags().Changed("tag-page-size") {
+		if tagPageSize <= 0 {
+			return fmt.Errorf("--tag-page-size must be greater than zero")
+		}
+		cfg.TagPageSize = tagPageSize
+	}
+	if cmd.Flags().Changed("max-repository-tags") {
+		if maxRepositoryTags < 0 {
+			return fmt.Errorf("--max-repository-tags must be greater than or equal to zero")
+		}
+		cfg.MaxRepositoryTags = maxRepositoryTags
+	}
+	if cmd.Flags().Changed("max-repository-targets") {
+		if maxRepositoryTargets < 0 {
+			return fmt.Errorf("--max-repository-targets must be greater than or equal to zero")
+		}
+		cfg.MaxRepositoryTargets = maxRepositoryTargets
+	}
+	return nil
 }
 
 func renderSummary(output io.Writer, result jobs.Result) error {

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/brumbelow/layerleak/internal/manifest"
@@ -258,6 +259,290 @@ func TestScanCommandWritesPartialResultsOnConfiguredLimitError(t *testing.T) {
 	}
 	if !strings.Contains(string(body), `"redacted_value"`) {
 		t.Fatalf("partial findings file missing redacted value field: %q", string(body))
+	}
+}
+
+func TestScanCommandRejectsInvalidScopeFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		flag string
+	}{
+		{"tag page size must be positive", "--tag-page-size=0"},
+		{"tag page size must be parsable", "--tag-page-size=-1"},
+		{"max repository tags must be non-negative", "--max-repository-tags=-1"},
+		{"max repository targets must be non-negative", "--max-repository-targets=-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LAYERLEAK_REGISTRY_BASE_URL", "https://registry.test")
+			t.Setenv("LAYERLEAK_FINDINGS_DIR", t.TempDir())
+
+			command := newRootCmd()
+			command.SetOut(io.Discard)
+			command.SetErr(io.Discard)
+			command.SetContext(context.Background())
+			command.SetArgs([]string{"scan", "library/app:latest", "--format", "json", tc.flag})
+
+			err := command.Execute()
+			if err == nil {
+				t.Fatalf("Execute() error = nil for %s", tc.flag)
+			}
+			if !strings.Contains(err.Error(), "must be") {
+				t.Fatalf("Execute() err = %q, want validation message", err.Error())
+			}
+		})
+	}
+}
+
+func TestScanCommandRepositorySweepUsesTagPageSizeFlag(t *testing.T) {
+	var (
+		mu              sync.Mutex
+		observedQueries []string
+	)
+	configDigest := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	manifestDigest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return commandResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+
+		switch request.URL.Path {
+		case "/v2/library/app/tags/list":
+			mu.Lock()
+			observedQueries = append(observedQueries, request.URL.RawQuery)
+			mu.Unlock()
+			body, _ := json.Marshal(map[string]any{"name": "library/app", "tags": []string{"latest"}})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		case "/v2/library/app/manifests/latest":
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+configDigest+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": manifestDigest,
+			}), nil
+		case "/v2/library/app/manifests/" + manifestDigest:
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"`+configDigest+`","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": manifestDigest,
+			}), nil
+		case "/v2/library/app/blobs/" + configDigest:
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageConfig, []byte(`{"architecture":"amd64","os":"linux","config":{}}`), nil), nil
+		default:
+			return commandResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+		}
+	})
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = transport
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+
+	t.Setenv("LAYERLEAK_REGISTRY_BASE_URL", "https://registry.test")
+	t.Setenv("LAYERLEAK_FINDINGS_DIR", t.TempDir())
+
+	command := newRootCmd()
+	var stdout bytes.Buffer
+	command.SetOut(&stdout)
+	command.SetErr(&stdout)
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"scan", "library/app", "--format", "json", "--tag-page-size", "37"})
+
+	if err := command.Execute(); err != nil {
+		if _, ok := err.(interface{ ExitCode() int }); !ok {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(observedQueries) == 0 {
+		t.Fatalf("no tag list query observed")
+	}
+	for _, query := range observedQueries {
+		if !strings.Contains(query, "n=37") {
+			t.Fatalf("tag list query = %q, want n=37", query)
+		}
+	}
+}
+
+func TestScanCommandRepositorySweepHonorsMaxRepositoryTagsFlag(t *testing.T) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return commandResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+		if request.URL.Path == "/v2/library/app/tags/list" {
+			body, _ := json.Marshal(map[string]any{"name": "library/app", "tags": []string{"latest", "v1", "v2"}})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		return commandResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+	})
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = transport
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+
+	t.Setenv("LAYERLEAK_REGISTRY_BASE_URL", "https://registry.test")
+	t.Setenv("LAYERLEAK_FINDINGS_DIR", t.TempDir())
+
+	command := newRootCmd()
+	var stdout bytes.Buffer
+	command.SetOut(&stdout)
+	command.SetErr(&stdout)
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"scan", "library/app", "--format", "json", "--max-repository-tags", "1"})
+
+	err := command.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want limit exceeded")
+	}
+	if !strings.Contains(err.Error(), "max repository tags") {
+		t.Fatalf("Execute() err = %q, want repository tag limit error", err.Error())
+	}
+}
+
+func TestScanCommandRepositorySweepHonorsMaxRepositoryTargetsFlag(t *testing.T) {
+	firstDigest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	secondDigest := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return commandResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+		switch request.URL.Path {
+		case "/v2/library/app/tags/list":
+			body, _ := json.Marshal(map[string]any{"name": "library/app", "tags": []string{"v1", "v2"}})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		case "/v2/library/app/manifests/v1":
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": firstDigest,
+			}), nil
+		case "/v2/library/app/manifests/v2":
+			return commandResponse(http.StatusOK, manifest.MediaTypeOCIImageManifest, []byte(`{"schemaVersion":2,"mediaType":"`+manifest.MediaTypeOCIImageManifest+`","config":{"mediaType":"`+manifest.MediaTypeOCIImageConfig+`","digest":"sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","size":1},"layers":[]}`), map[string]string{
+				"Docker-Content-Digest": secondDigest,
+			}), nil
+		}
+		return commandResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+	})
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = transport
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+
+	t.Setenv("LAYERLEAK_REGISTRY_BASE_URL", "https://registry.test")
+	t.Setenv("LAYERLEAK_FINDINGS_DIR", t.TempDir())
+
+	command := newRootCmd()
+	var stdout bytes.Buffer
+	command.SetOut(&stdout)
+	command.SetErr(&stdout)
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"scan", "library/app", "--format", "json", "--max-repository-targets", "1"})
+
+	err := command.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want repository target limit error")
+	}
+	if !strings.Contains(err.Error(), "max repository targets") {
+		t.Fatalf("Execute() err = %q, want repository target limit error", err.Error())
+	}
+}
+
+func TestScanCommandWarnsOnBareRepositorySweep(t *testing.T) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return commandResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+		// Make the tag list fail so the run terminates quickly; the warning must
+		// be emitted before tag enumeration begins.
+		return commandResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+	})
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = transport
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+
+	t.Setenv("LAYERLEAK_REGISTRY_BASE_URL", "https://registry.test")
+	t.Setenv("LAYERLEAK_FINDINGS_DIR", t.TempDir())
+
+	command := newRootCmd()
+	var stdout bytes.Buffer
+	command.SetOut(io.Discard)
+	command.SetErr(&stdout)
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"scan", "library/app", "--format", "json"})
+
+	_ = command.Execute()
+
+	output := stdout.String()
+	if !strings.Contains(output, "enumerates every public tag") {
+		t.Fatalf("stderr missing bare repository sweep warning: %q", output)
+	}
+}
+
+func TestScanCommandDoesNotWarnOnPinnedReference(t *testing.T) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host == "auth.test" {
+			body, _ := json.Marshal(map[string]string{"token": "test-token"})
+			return commandResponse(http.StatusOK, "application/json", body, nil), nil
+		}
+		if request.Header.Get("Authorization") != "Bearer test-token" {
+			return commandResponse(http.StatusUnauthorized, "", nil, map[string]string{
+				"Www-Authenticate": `Bearer realm="https://auth.test/token",service="registry.test",scope="repository:library/app:pull"`,
+			}), nil
+		}
+		return commandResponse(http.StatusNotFound, "text/plain", []byte("not found"), nil), nil
+	})
+
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = transport
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+
+	t.Setenv("LAYERLEAK_REGISTRY_BASE_URL", "https://registry.test")
+	t.Setenv("LAYERLEAK_FINDINGS_DIR", t.TempDir())
+
+	command := newRootCmd()
+	var stdout bytes.Buffer
+	command.SetOut(io.Discard)
+	command.SetErr(&stdout)
+	command.SetContext(context.Background())
+	command.SetArgs([]string{"scan", "library/app:latest", "--format", "json"})
+
+	_ = command.Execute()
+
+	if strings.Contains(stdout.String(), "enumerates every public tag") {
+		t.Fatalf("pinned reference run should not warn about bare repository sweep: %q", stdout.String())
 	}
 }
 

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+func effectiveVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	return resolveVersion(Version, info, ok)
+}
+
+func resolveVersion(explicit string, info *debug.BuildInfo, infoOK bool) string {
+	trimmed := strings.TrimSpace(explicit)
+	if trimmed != "" && trimmed != "dev" {
+		return trimmed
+	}
+	if infoOK && info != nil {
+		mainVersion := strings.TrimSpace(info.Main.Version)
+		if mainVersion != "" && mainVersion != "(devel)" {
+			return mainVersion
+		}
+	}
+	return "dev"
+}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestEffectiveVersionPrefersExplicitVersion(t *testing.T) {
+	got := resolveVersion("v1.2.3", &debug.BuildInfo{Main: debug.Module{Version: "v9.9.9"}}, true)
+	if got != "v1.2.3" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "v1.2.3")
+	}
+}
+
+func TestEffectiveVersionFallsBackToBuildInfoWhenExplicitIsDev(t *testing.T) {
+	got := resolveVersion("dev", &debug.BuildInfo{Main: debug.Module{Version: "v1.4.0"}}, true)
+	if got != "v1.4.0" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "v1.4.0")
+	}
+}
+
+func TestEffectiveVersionFallsBackToBuildInfoWhenExplicitIsBlank(t *testing.T) {
+	got := resolveVersion("", &debug.BuildInfo{Main: debug.Module{Version: "v1.4.0"}}, true)
+	if got != "v1.4.0" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "v1.4.0")
+	}
+}
+
+func TestEffectiveVersionFallsBackToDevWhenBuildInfoIsDevel(t *testing.T) {
+	got := resolveVersion("dev", &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}}, true)
+	if got != "dev" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "dev")
+	}
+}
+
+func TestEffectiveVersionFallsBackToDevWhenBuildInfoIsEmpty(t *testing.T) {
+	got := resolveVersion("dev", &debug.BuildInfo{}, true)
+	if got != "dev" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "dev")
+	}
+}
+
+func TestEffectiveVersionFallsBackToDevWhenBuildInfoUnavailable(t *testing.T) {
+	got := resolveVersion("dev", nil, false)
+	if got != "dev" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "dev")
+	}
+}

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -119,7 +119,12 @@ go build -o layerleak .
 ./layerleak scan alpine:latest --platform linux/amd64</code></pre>
               <p class="muted">
                 To pin a published release, replace <code>@latest</code> with the
-                <code>v1.x.y</code> tag you want.
+                <code>v1.x.y</code> tag you want. The module path is
+                <code>github.com/brumbelow/layerleak</code>, so <code>@latest</code> resolves to the
+                highest published <code>v1.x.y</code> tag. Module-installed binaries report that
+                version through <code>layerleak --version</code>; local checkout builds report the
+                version Go embeds for the checkout, falling back to <code>dev</code> when no module
+                version is available.
               </p>
             </section>
 
@@ -142,7 +147,7 @@ layerleak scan repo/app@sha256:...</code></pre>
                 </article>
                 <article>
                   <h3>Repository sweep</h3>
-                  <p>Bare repository names enumerate public tags, resolve each tag to a digest, and group duplicate digests.</p>
+                  <p>Bare repository names enumerate every public tag, resolve each tag to a digest, and group duplicate digests. A warning is printed to stderr before the sweep starts so the scope is obvious in CI logs.</p>
                   <pre><code>layerleak scan mongo
 layerleak scan quay.io/prometheus/busybox</code></pre>
                 </article>
@@ -152,6 +157,16 @@ layerleak scan quay.io/prometheus/busybox</code></pre>
                 <code>--platform os/arch[/variant]</code>. Attestation and provenance manifests
                 (for example <code>application/vnd.in-toto+json</code>) are skipped instead of
                 counted as platform scan failures.
+              </p>
+              <p>
+                Repository sweeps accept per-command scope flags that override the matching
+                environment variables: <code>--tag-page-size</code> for tag-list page size,
+                <code>--max-repository-tags</code> to cap how many tags are enumerated, and
+                <code>--max-repository-targets</code> to cap how many distinct digests are
+                resolved. <code>--max-repository-tags</code> and
+                <code>--max-repository-targets</code> accept <code>0</code> to disable the cap;
+                <code>--tag-page-size</code> must be greater than zero. These flags are
+                non-interactive and safe for automation.
               </p>
               <p>
                 Detection uses native detectors for 60+ secret types, with TruffleHog defaults as a


### PR DESCRIPTION
## Summary
- Documents the root-module `v1.x.y` release policy and updates release/install guidance for the next `v1.1.0` release train.
- Makes `layerleak --version` report the Go module build-info version for module-installed binaries while preserving explicit version overrides.
- Adds repository sweep scope flags for tag page size, max enumerated tags, and max resolved targets.
- Improves bare repository scan messaging so repository-wide tag enumeration is visible in automation output.
- Adds CI install smoke coverage for the installed CLI help and version commands.

## Testing
- `git diff --check`
- `go test ./internal/cli ./internal/config ./internal/scanservice -count=1`
- `go vet ./...`
- `go test ./... -count=1`
- `node --check web/assets/site.js`
- `node --check web/assets/demo.js`
- `GOBIN=/tmp/layerleak-bin GOCACHE=/tmp/layerleak-gocache go install .`
- `/tmp/layerleak-bin/layerleak --help`
- `/tmp/layerleak-bin/layerleak scan --help`
- `/tmp/layerleak-bin/layerleak --version`

## Release note
This does not create a release tag. The next root-module release should be cut as `v1.1.0` after merge.