### PR TITLE
ci: validate compose config and refresh docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,16 @@ jobs:
           "${install_bin}/layerleak" --help
           "${install_bin}/layerleak" scan --help
           "${install_bin}/layerleak" --version
+
+  compose-config:
+    name: docker compose config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate default compose config
+        run: docker compose -f docker-compose.yml config -q
+
+      - name: Validate compose config with manual profile
+        run: docker compose -f docker-compose.yml --profile manual config -q

--- a/README.md
+++ b/README.md
@@ -285,12 +285,14 @@ Current endpoints:
 `GET /health` returns `{"status":"ok"}` and does not require a configured store or scanner.
 It is suitable for Kubernetes readiness probes and Docker Compose `healthcheck` targets.
 
-`POST /api/v1/scans` stays synchronous and now returns `scan_run_id` whenever Postgres persistence is enabled.
+`POST /api/v1/scans` stays synchronous. It accepts a JSON body with `reference` and optional `platform`, and returns `scan_run_id` whenever Postgres persistence is enabled.
 API scan responses reuse the same redacted result schema as the CLI JSON output.
 `GET /api/v1/scans/{id}` returns the persisted run metadata plus the stored redacted result snapshot.
 Repository and finding endpoints also stay redacted: they return `redacted_value` and redacted `context_snippet`, never raw secret values or raw snippets from Postgres.
 
 `GET /api/v1/repositories/{repository}/scans` and `GET /api/v1/repositories/{repository}/findings` accept an optional `registry` query parameter (for example `?registry=ghcr.io`). When omitted, the registry defaults to `docker.io` for backward compatibility. Use this to fetch scans of repositories on GHCR, Quay, GCR, MCR, Amazon ECR Public, or any self-hosted registry.
+
+List endpoints (`/repositories`, `/repositories/{repository}/scans`, `/repositories/{repository}/findings`) accept `?limit=` and `?offset=` for pagination. `limit` defaults to `50` and is capped at `200`. `/repositories/{repository}/findings` also accepts `?disposition=actionable|suppressed|all`; when omitted the response only includes actionable findings.
 
 The API does not include authentication.
 For org deployments, keep it on a private network and front it with your own authn/authz gateway or reverse proxy policy.
@@ -309,6 +311,12 @@ export LAYERLEAK_DB_NAME=layerleak
 export LAYERLEAK_DB_USER=layerleak
 export LAYERLEAK_DB_PASSWORD=replace-me
 export LAYERLEAK_API_PORT=8080
+```
+
+Validate the rendered Compose configuration before deployment:
+
+```bash
+docker compose config
 ```
 
 Run migrations once before starting the API:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,6 +20,7 @@
 
 ```bash
 go test ./... -count=1
+docker compose config
 GOBIN=/tmp/layerleak-bin GOCACHE=/tmp/layerleak-gocache go install .
 /tmp/layerleak-bin/layerleak --help
 /tmp/layerleak-bin/layerleak scan --help

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -200,7 +200,9 @@ LAYERLEAK_MAX_TAG_RESPONSE_BYTES=8388608
 LAYERLEAK_MAX_REPOSITORY_TAGS=0
 LAYERLEAK_MAX_REPOSITORY_TARGETS=0
 LAYERLEAK_REGISTRY_REQUEST_ATTEMPTS=2
-LAYERLEAK_DATABASE_URL=postgres://postgres:postgres@localhost:5432/layerleak?sslmode=disable</code></pre>
+LAYERLEAK_REGISTRY_BASE_URL=
+LAYERLEAK_REGISTRY_AUTH_URL=
+LAYERLEAK_DATABASE_URL=postgres://postgres:***@localhost:5432/layerleak?sslmode=disable</code></pre>
               <ul class="config-notes">
                 <li>
                   <strong>Limits.</strong> Settings with a non-negative semantic
@@ -340,8 +342,9 @@ psql "$LAYERLEAK_DATABASE_URL" -f migrations/0003_scan_runs.up.sql</code></pre>
                 Repository scan and finding list endpoints accept an optional
                 <code>?registry=</code> query parameter (defaults to <code>docker.io</code>),
                 plus <code>?limit=</code> and <code>?offset=</code> pagination
-                (max <code>limit</code> is 200). Findings list also accepts
-                <code>?disposition=actionable|suppressed|all</code>.
+                (<code>limit</code> defaults to 50 and is capped at 200). Findings list also
+                accepts <code>?disposition=actionable|suppressed|all</code>; omitted
+                <code>disposition</code> returns actionable findings only.
               </p>
               <div class="callout callout-warn" role="note">
                 <strong>No built-in auth</strong>
@@ -370,7 +373,9 @@ docker run --rm \
                 <code>db</code> service baseline is pinned to
                 <code>postgres:16.13-alpine</code>.
               </p>
-              <pre><code>docker compose --profile manual run --rm migrate
+              <pre><code>docker compose config
+
+docker compose --profile manual run --rm migrate
 docker compose up -d api</code></pre>
               <p>
                 In Dockge or Komodo, import the same Compose file and run the <code>migrate</code>


### PR DESCRIPTION
## Summary
- Adds CI coverage for rendering the checked-in Docker Compose configuration, including the manual migration profile.
- Documents `docker compose config` in release and deployment guidance.
- Aligns README and web docs with current API request/query parameters and documented environment variables.

## Validation
- `go test ./... -count=1`
- `go vet ./...`
- `node --check web/assets/site.js`
- `node --check web/assets/demo.js`
- `git diff --check`
- Source/docs consistency check for API routes and `LAYERLEAK_*` configuration variables
