### PR TITLE
Finish v1.1 release cleanup

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,4 +1,8 @@
 ---
+engines:
+  revive:
+    exclude_paths:
+      - "go.sum"
 exclude_paths:
   - ".github/**"
   - "migrations/**"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,19 +36,24 @@ Complete these settings before the first RC:
 1. Enable GitHub immutable releases for the repository.
 2. Create a `release` environment with required maintainer review. Restrict it
    to `main` and do not allow administrators to bypass approval casually.
-3. Allow Actions to request read/write `GITHUB_TOKEN` permissions.
+3. Keep the default `GITHUB_TOKEN` permissions read-only. The release workflow
+   grants required write scopes only to the jobs that publish evidence or the
+   release.
 4. Protect `main` with pull requests, no force pushes or deletion, and all CI,
    CodeQL, and Codacy checks required.
-5. Add a tag ruleset for `v1.*` that blocks update/deletion and permits creation
-   only by the protected release path. The workflow's token must be allowed to
-   create a new tag after approval.
+5. Add a tag ruleset for `v1.*` that blocks updates, deletion, and non-fast-
+   forward changes with no bypass. Personal repositories cannot select the
+   GitHub Actions integration as a ruleset bypass actor, so leave initial tag
+   creation enabled for the protected workflow and do not create tags manually.
 6. Enable dependency graph, Dependabot, secret scanning, push protection, code
    scanning, and artifact attestations.
 7. Make `ghcr.io/brumbelow/layerleak` public after its initial publication.
 
 The workflow uses only `GITHUB_TOKEN` and GitHub's OIDC token. It does not
 require a Cosign private key, registry password, PAT, or custom release secret.
-Codacy continues to require `CODACY_PROJECT_TOKEN` for its separate workflow.
+The public-repository GitHub code-scanning workflow runs without a
+`CODACY_PROJECT_TOKEN`; configure the optional secret only when the scan must
+retrieve remote Codacy project settings.
 `GITHUB_TOKEN` cannot read repository Administration settings, so enabling
 immutable releases remains a required setup step. The workflow checks every
 existing candidate/release and verifies `isImmutable` plus the GitHub release

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7,7 +7,7 @@ license terms.
 | Module | Version | License |
 | --- | --- | --- |
 | `github.com/distribution/reference` | v0.6.0 | Apache-2.0 |
-| `github.com/klauspost/compress` | v1.19.1 | Apache-2.0, BSD-3-Clause, and MIT components |
+| `github.com/klauspost/compress` | v1.19.2 | Apache-2.0, BSD-3-Clause, and MIT components |
 | `github.com/lib/pq` | v1.12.3 | MIT |
 | `github.com/opencontainers/go-digest` | v1.0.0 | Apache-2.0 |
 | `github.com/spf13/cobra` | v1.10.2 | Apache-2.0 |

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require golang.org/x/sys v0.47.0 // indirect
 
-require github.com/klauspost/compress v1.19.1
+require github.com/klauspost/compress v1.19.2
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
-github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
+github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
 github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -74,10 +74,6 @@ type progressRenderer struct {
 	state      progressSnapshot
 }
 
-func newProgressRenderer(out io.Writer) *progressRenderer {
-	return newProgressRendererWithMode(out, progressModeAuto)
-}
-
 func newProgressRendererWithMode(out io.Writer, mode progressMode) *progressRenderer {
 	terminalFD, ok := terminalFileDescriptor(out)
 	if !ok {

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -2,12 +2,17 @@ package cli
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/brumbelow/layerleak/internal/jobs"
 	"github.com/brumbelow/layerleak/internal/manifest"
 )
+
+func newProgressRenderer(out io.Writer) *progressRenderer {
+	return newProgressRendererWithMode(out, progressModeAuto)
+}
 
 func TestProgressRendererRendersLogoAndStatusBlock(t *testing.T) {
 	const wantLogo = `

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -608,10 +608,6 @@ func TestScanCommandBareReferenceDefaultsToLatestWithoutTagEnumeration(t *testin
 
 type roundTripFunc func(request *http.Request) (*http.Response, error)
 
-func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
-	return f(request)
-}
-
 func commandResponse(statusCode int, contentType string, body []byte, headers map[string]string) *http.Response {
 	header := make(http.Header)
 	for key, value := range headers {

--- a/internal/detectors/detectors.go
+++ b/internal/detectors/detectors.go
@@ -607,10 +607,10 @@ func looksLikeAWSSecretAccessKey(value string) bool {
 	return hasLower && hasUpper
 }
 
-func hasMinPrintableLength(min int) func(string) bool {
+func hasMinPrintableLength(minLength int) func(string) bool {
 	return func(value string) bool {
 		trimmed := strings.TrimSpace(value)
-		return len(trimmed) >= min && isPrintableText(trimmed)
+		return len(trimmed) >= minLength && isPrintableText(trimmed)
 	}
 }
 

--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -646,15 +646,6 @@ func validUTF8Prefix(value string, maxBytes int) string {
 	return value[:end]
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
-}
-
 func isValidSourceType(value SourceType) bool {
 	switch value {
 	case SourceTypeFileFinal, SourceTypeFileDeletedLayer, SourceTypeEnv, SourceTypeLabel, SourceTypeHistory, SourceTypeConfig:

--- a/internal/layers/state_test.go
+++ b/internal/layers/state_test.go
@@ -29,7 +29,7 @@ func TestReplayTracksDeletedArtifacts(t *testing.T) {
 	result, err := Replay(context.Background(), []manifest.Descriptor{
 		{Digest: "sha256:one", MediaType: manifest.MediaTypeDockerSchema2LayerGzip},
 		{Digest: "sha256:two", MediaType: manifest.MediaTypeDockerSchema2LayerGzip},
-	}, ReplayOptions{MaxFileBytes: 1 << 20}, OpenFunc(func(ctx context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
+	}, ReplayOptions{MaxFileBytes: 1 << 20}, OpenFunc(func(_ context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
 		switch descriptor.Digest {
 		case "sha256:one":
 			return io.NopCloser(bytes.NewReader(layerOne)), nil
@@ -125,7 +125,7 @@ func TestReplayTracksOverwrittenFilesAndOpaqueWhiteout(t *testing.T) {
 	result, err := Replay(context.Background(), []manifest.Descriptor{
 		{Digest: "sha256:one", MediaType: manifest.MediaTypeDockerSchema2LayerGzip},
 		{Digest: "sha256:two", MediaType: manifest.MediaTypeDockerSchema2LayerGzip},
-	}, ReplayOptions{MaxFileBytes: 1 << 20}, OpenFunc(func(ctx context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
+	}, ReplayOptions{MaxFileBytes: 1 << 20}, OpenFunc(func(_ context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
 		switch descriptor.Digest {
 		case "sha256:one":
 			return io.NopCloser(bytes.NewReader(layerOne)), nil
@@ -158,7 +158,7 @@ func TestReplaySupportsZstd(t *testing.T) {
 
 	result, err := Replay(context.Background(), []manifest.Descriptor{
 		{Digest: "sha256:zstd", MediaType: manifest.MediaTypeOCIImageLayerZstd},
-	}, ReplayOptions{MaxFileBytes: 1 << 20}, OpenFunc(func(ctx context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
+	}, ReplayOptions{MaxFileBytes: 1 << 20}, OpenFunc(func(_ context.Context, _ manifest.Descriptor) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(layer)), nil
 	}))
 	if err != nil {
@@ -373,7 +373,7 @@ func TestReplayClassifiesRegularFilesBeforeScanning(t *testing.T) {
 
 	result, err := Replay(context.Background(), []manifest.Descriptor{
 		{Digest: "sha256:classified", MediaType: manifest.MediaTypeDockerSchema2LayerGzip},
-	}, ReplayOptions{MaxFileBytes: 1 << 20}, OpenFunc(func(ctx context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
+	}, ReplayOptions{MaxFileBytes: 1 << 20}, OpenFunc(func(_ context.Context, _ manifest.Descriptor) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(layer)), nil
 	}))
 	if err != nil {
@@ -429,7 +429,7 @@ func TestReplayReturnsPartialResultWhenGzipLayerByteLimitExceeded(t *testing.T) 
 	}, ReplayOptions{
 		MaxFileBytes:  1 << 20,
 		MaxLayerBytes: 1536,
-	}, OpenFunc(func(ctx context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
+	}, OpenFunc(func(_ context.Context, _ manifest.Descriptor) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(layer)), nil
 	}))
 	if err == nil {
@@ -462,7 +462,7 @@ func TestReplayReturnsPartialResultWhenZstdLayerByteLimitExceeded(t *testing.T) 
 	}, ReplayOptions{
 		MaxFileBytes:  1 << 20,
 		MaxLayerBytes: 1536,
-	}, OpenFunc(func(ctx context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
+	}, OpenFunc(func(_ context.Context, _ manifest.Descriptor) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(layer)), nil
 	}))
 	if err == nil {
@@ -573,7 +573,7 @@ func TestReplayReturnsPartialResultWhenLayerEntryLimitExceeded(t *testing.T) {
 	}, ReplayOptions{
 		MaxFileBytes:    1 << 20,
 		MaxLayerEntries: 1,
-	}, OpenFunc(func(ctx context.Context, descriptor manifest.Descriptor) (io.ReadCloser, error) {
+	}, OpenFunc(func(_ context.Context, _ manifest.Descriptor) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(layer)), nil
 	}))
 	if err == nil {

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -454,7 +454,7 @@ func TestListTagsReturnsPartialTagsWhenTagResponseLimitExceededMidPagination(t *
 }
 
 func TestListTagsRejectsPaginationCycle(t *testing.T) {
-	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	transport := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		return jsonResponse(http.StatusOK, "application/json", []byte(`{"name":"library/app","tags":["latest"]}`), map[string]string{
 			"Link": `<https://registry.test/v2/library/app/tags/list?n=100>; rel="next"`,
 		}), nil

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -328,10 +328,6 @@ func Scan(ctx context.Context, request Request) (Result, error) {
 	return result, nil
 }
 
-func scanManifest(ctx context.Context, request Request, descriptor manifest.Descriptor, preloaded *manifest.ImageManifest) (PlatformResult, []findings.DetailedFinding, []findings.DetailedFinding, error) {
-	return scanManifestWithBudget(ctx, request, descriptor, preloaded, newDetectionBudget(ctx, request))
-}
-
 func scanManifestWithBudget(ctx context.Context, request Request, descriptor manifest.Descriptor, preloaded *manifest.ImageManifest, budget *detectionBudget) (PlatformResult, []findings.DetailedFinding, []findings.DetailedFinding, error) {
 	platformResult := PlatformResult{
 		Status:         ResultStatusFailed,
@@ -766,10 +762,6 @@ func scanMetadataWithBudget(budget *detectionBudget, detectorSet detectors.Set, 
 	return result
 }
 
-func scanArtifacts(detectorSet detectors.Set, manifestDigest string, platform manifest.Platform, sourceType findings.SourceType, presentInFinalImage bool, artifacts []layers.Artifact) []findings.DetailedFinding {
-	return scanArtifactsWithBudget(&detectionBudget{retainRaw: true}, detectorSet, manifestDigest, platform, sourceType, presentInFinalImage, artifacts)
-}
-
 func scanArtifactsWithBudget(budget *detectionBudget, detectorSet detectors.Set, manifestDigest string, platform manifest.Platform, sourceType findings.SourceType, presentInFinalImage bool, artifacts []layers.Artifact) []findings.DetailedFinding {
 	result := make([]findings.DetailedFinding, 0)
 	for _, artifact := range artifacts {
@@ -893,15 +885,6 @@ func collectErrorMessages(limit int, message func(index int) string) []string {
 
 func isCancellationError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
 }
 
 func emitProgress(request Request, update ProgressUpdate) {

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/brumbelow/layerleak/internal/registry"
 )
 
+func scanArtifacts(detectorSet detectors.Set, manifestDigest string, platform manifest.Platform, sourceType findings.SourceType, presentInFinalImage bool, artifacts []layers.Artifact) []findings.DetailedFinding {
+	return scanArtifactsWithBudget(&detectionBudget{retainRaw: true}, detectorSet, manifestDigest, platform, sourceType, presentInFinalImage, artifacts)
+}
+
 func TestScanMultiArchImage(t *testing.T) {
 	amd64LayerOne := gzipLayer(t, []tarEntry{
 		{name: "app/.env", body: "STRIPE=sk_live_abcdefghijklmnopqrstuvwxyz12"},

--- a/revive.toml
+++ b/revive.toml
@@ -3,6 +3,9 @@ enableDefaultRules = true
 [rule.exported]
 Disabled = true
 
+[rule.package-comments]
+Disabled = true
+
 [rule.early-return]
 
 [rule.bool-literal-in-expr]


### PR DESCRIPTION
## Summary

Finish the remaining cleanup before the v1.1 release candidate.

## Changes

- update klauspost/compress to v1.19.2 and refresh the third-party notice
- clear the remaining Revive and dead-code findings without changing runtime behavior
- align Codacy and release documentation with the repository's protected release settings

## Testing

- full normal and race test suites with Go 1.25.13
- `go vet ./...` and `go build ./...`
- linux/amd64 and linux/arm64 static builds
- vulnerability and dependency-license checks
- Revive, dead-code, workflow, YAML, shell, OpenAPI, and Markdown checks