### PR TITLE
Add Codacy coverage reporting

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -3,13 +3,14 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-# This workflow checks out code, performs a Codacy security scan
-# and integrates the results with the
-# GitHub Advanced Security code scanning feature.  For more information on
-# the Codacy security scan action usage and parameters, see
+# This workflow performs a Codacy security scan, integrates the results with
+# GitHub Advanced Security code scanning, and uploads Go test coverage to
+# Codacy. For more information on the Codacy security scan action, see
 # https://github.com/codacy/codacy-analysis-cli-action.
 # For more information on Codacy Analysis CLI in general, see
 # https://github.com/codacy/codacy-analysis-cli.
+# For more information on Codacy Coverage Reporter, see
+# https://docs.codacy.com/coverage-reporter/.
 
 name: Codacy Security Scan
 
@@ -81,3 +82,61 @@ jobs:
           sarif_file: results-combined.sarif
           category: Codacy
           wait-for-processing: true
+
+  codacy-coverage:
+    name: Codacy Coverage
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      GOFLAGS: -mod=readonly
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Generate Go coverage report
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test -short ./... -count=1 -covermode=atomic -coverprofile=unit.coverage.out
+          test -s unit.coverage.out
+
+      - name: Upload coverage to Codacy
+        shell: bash
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          CODACY_REPORTER_VERSION: "14.1.3"
+          CODACY_REPORTER_SHA512: 73a6c93fc5db509fd0423d6e545759c3f61d8360ee12054e32a9277daab6add0da6c6639248f6ed6c0042366440293ebc0b6144325aef52c5d3d4b230d65eb17
+          COVERAGE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CODACY_PROJECT_TOKEN}" ]]; then
+            echo "CODACY_PROJECT_TOKEN is required for coverage uploads." >&2
+            exit 1
+          fi
+
+          reporter="${RUNNER_TEMP}/codacy-coverage-reporter"
+          curl --fail --location --silent --show-error \
+            --output "${reporter}" \
+            "https://github.com/codacy/codacy-coverage-reporter/releases/download/${CODACY_REPORTER_VERSION}/codacy-coverage-reporter-linux"
+          echo "${CODACY_REPORTER_SHA512}  ${reporter}" | sha512sum --check
+          chmod +x "${reporter}"
+          "${reporter}" report \
+            --commit-uuid "${COVERAGE_COMMIT}" \
+            --force-coverage-parser go \
+            -r unit.coverage.out

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,9 +51,10 @@ Complete these settings before the first RC:
 
 The workflow uses only `GITHUB_TOKEN` and GitHub's OIDC token. It does not
 require a Cosign private key, registry password, PAT, or custom release secret.
-The public-repository GitHub code-scanning workflow runs without a
-`CODACY_PROJECT_TOKEN`; configure the optional secret only when the scan must
-retrieve remote Codacy project settings.
+The public-repository GitHub code-scanning workflow can run without a
+`CODACY_PROJECT_TOKEN`, but the Codacy coverage job requires that repository
+secret to upload Go coverage reports. The analysis job also uses it to retrieve
+remote Codacy project settings.
 `GITHUB_TOKEN` cannot read repository Administration settings, so enabling
 immutable releases remains a required setup step. The workflow checks every
 existing candidate/release and verifies `isImmutable` plus the GitHub release


### PR DESCRIPTION
## Summary

Add Go coverage reporting to Codacy so new commits and pull requests no longer show missing coverage requirements.

## Root cause

The existing Codacy workflow uploaded static-analysis SARIF only. Go tests ran without a coverage profile, leaving the coverage reporter with nothing to upload.

## Changes

- generate an atomic Go coverage profile on trusted pushes and pull requests
- upload it with Codacy Coverage Reporter 14.1.3 after SHA-512 verification
- associate reports with the PR head or push commit explicitly
- keep the project token scoped to the upload step and avoid privileged fork execution
- document that the coverage job requires the repository token

## Testing

- Go 1.25.13 short suite with atomic coverage: 68.6%
- reporter release checksum and CLI arguments verified
- actionlint and workflow YAML parsing
- Bash syntax and whitespace checks

The live Codacy upload is intentionally left to this pull request's workflow run so it uses the repository secret and the exact published commit.