### PR TITLE
Fix metadata linting and browser CI setup

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,5 +1,10 @@
 ---
 engines:
+  tslint:
+    # npm metadata is strict JSON, not TypeScript with trailing commas.
+    exclude_paths:
+      - "scripts/tests/package.json"
+      - "scripts/tests/package-lock.json"
   revive:
     exclude_paths:
       - "go.sum"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -123,7 +123,10 @@ jobs:
         run: npm ci --prefix scripts/tests
 
       - name: Install test browser
-        run: scripts/tests/node_modules/.bin/playwright install --with-deps chromium
+        run: |
+          # Playwright downloads Chromium itself; the runner's Chrome APT source is unrelated.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list /etc/apt/sources.list.d/google-chrome*.sources
+          scripts/tests/node_modules/.bin/playwright install --with-deps chromium
 
       - name: Test synthetic demo rendering
         run: npm test --prefix scripts/tests


### PR DESCRIPTION
TSLint applies TypeScript object-key and trailing-comma rules to the browser test package.json and package-lock.json introduced in #137, producing 18 invalid formatting requests. Trailing commas would break npm's strict JSON format.

Exclude only those two files from TSLint. Dependency review, strict JSON parsing through npm, and every other analyzer remain unchanged. This does not disable TSLint for source files.

The post-merge browser setup also failed twice on a hash mismatch in the runner's Google Chrome APT index. Remove only that unrelated source in the temporary runner before installing Playwright's Ubuntu dependencies. Playwright downloads its own Chromium build; package integrity checks remain unchanged.

Verified that the YAML parses, removing the new Codacy entry yields the previous configuration exactly, and both npm files remain valid JSON and byte-identical to main. Actionlint and whitespace checks pass. Hosted analysis and browser tests provide the final verification.
